### PR TITLE
Curated zone (Spec 2) + orphaned-scraping reaper

### DIFF
--- a/docs/superpowers/plans/2026-06-04-curated-zone.md
+++ b/docs/superpowers/plans/2026-06-04-curated-zone.md
@@ -1,0 +1,1806 @@
+# Curated Zone Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Transform the Spec 1 raw JSONL zone into a curated Parquet data lake with World Aquatics points, authoritative para classification, and flattened splits, cataloged in Glue for Athena/DuckDB.
+
+**Architecture:** A new pure-functional `curate/` Python package under `st-scrape/` (sibling to `ingestion/`), mirroring the existing inject-the-side-effects style (`run_cycle`/`run_scrape_task`): pure transform functions are unit-tested with no AWS, and a thin `run_curate_task`/`main` wires real boto3 + pyarrow. A new `SwimtrendsCuratedStack` (CDK) adds a curated Fargate task, an S3-event trigger Lambda, a class-overrides DynamoDB table, and Glue catalog tables. Reuses the Spec 1 bucket, ECS cluster, and SNS topic.
+
+**Tech Stack:** Python 3.12, pyarrow (Parquet), boto3, DynamoDB, S3, AWS Glue, AWS CDK (Python), pytest + moto.
+
+---
+
+## File structure
+
+Created under `st-scrape/curate/` (new package):
+
+- `curate/__init__.py` — package marker.
+- `curate/points.py` — pure WA points logic (ported from `calc_points.py`).
+- `curate/classify.py` — authoritative class resolution (override-else-heuristic).
+- `curate/model.py` — build curated table rows from raw dicts (incl. `result_id`).
+- `curate/transform.py` — pure `transform_meet()` orchestration → table→rows dict.
+- `curate/parquet.py` — pyarrow schemas + `write_parquet_bytes()` + partition paths.
+- `curate/overrides.py` — DynamoDB class-overrides access layer.
+- `curate/basetimes.py` — load base times from an S3 object (or local file).
+- `curate/catalog.py` — Glue table definitions + create/update.
+- `curate/run.py` — `run_curate_task()` (injected I/O) + `main()` container entry.
+
+Modified:
+
+- `st-scrape/requirements.txt` — add `pyarrow`.
+- `st-scrape/requirements-dev.txt` — moto already covers s3/dynamodb; add `pyarrow` via requirements.
+- `st-scrape/ingestion/cli.py` — add `curate`, `class`, `basetimes` subcommands.
+- `swimtrends-app/swimtrends_app/swimtrends_curated_stack.py` — new CDK stack.
+- `swimtrends-app/app.py` — instantiate the curated stack.
+- `swimtrends-app/tests/unit/test_curated_stack.py` — CDK assertions.
+
+Test files: one per module under `st-scrape/tests/` (e.g. `tests/test_curate_points.py`).
+
+## Curated schemas (authoritative reference for all tasks)
+
+All tables partitioned by `season` (int) then `course` (str), written one Parquet
+file per meet: `curated/<table>/season=<s>/course=<c>/meet=<meet_id>.parquet`.
+
+- **dim_meet:** `meet_id`(str), `meet_name`(str), `venue`(str), `course`(str), `season`(int), `meet_date`(str, `DD-MM-YYYY` from raw), `category`(list<str>).
+- **dim_race:** `race_id`(int), `meet_id`(str), `number`(int), `name`(str), `distance`(int), `stroke`(str), `gender`(str), `relay_count`(int), `type`(str), `class`(str), `season`(int), `course`(str).
+- **fact_result:** `result_id`(str), `race_id`(int), `meet_id`(str), `rank`(int), `name`(str), `swimmer_id`(str|null), `nationality`(str), `club`(str), `birth_year`(int|null), `completed_time`(str), `completed_centiseconds`(int|null), `points`(int|null), `points_fixed`(int|null), `season`(int), `course`(str).
+- **fact_split:** `result_id`(str), `race_id`(int), `distance`(int), `split_time`(str), `split_centiseconds`(int|null), `cumulative_time`(str), `cumulative_centiseconds`(int|null), `season`(int), `course`(str).
+- **obt_result:** all `fact_result` columns **plus** `meet_name`, `venue`, `meet_date`, `number`, `race_name`(from race `name`), `distance`, `stroke`, `gender`, `relay_count`, `type`, `class`. (`season`/`course` already present.)
+
+**`result_id` = `f"{race_id}-{ordinal}"`** where `ordinal` is the 0-based index of the result among results of that race in raw file order. (NOT `Rank`: disqualified swims share `Rank = -1`, which would collide. File order is deterministic because the scraper overwrites raw deterministically.)
+
+**Scorability (ported from `calc_points.py`):** a result is scored only if its race is known, `completed_centiseconds` is not null, and `Rank != -1` (DQ). Otherwise `points = points_fixed = null`. Para races (authoritative `class == "para"`) are never scored: `points = points_fixed = null`.
+
+---
+
+## Task 1: Add pyarrow dependency
+
+**Files:**
+- Modify: `st-scrape/requirements.txt`
+
+- [ ] **Step 1: Add pyarrow to requirements.txt**
+
+Append a line to `st-scrape/requirements.txt` so it reads:
+
+```
+requests>=2.31
+beautifulsoup4>=4.12
+boto3>=1.34
+tzdata>=2024.1
+pyarrow>=15.0
+```
+
+- [ ] **Step 2: Install into the venv**
+
+Run: `cd st-scrape && .venv/bin/pip install -r requirements-dev.txt`
+Expected: pyarrow installs; `.venv/bin/python -c "import pyarrow; print(pyarrow.__version__)"` prints a version ≥ 15.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add st-scrape/requirements.txt
+git commit -m "build: add pyarrow for curated Parquet output"
+```
+
+---
+
+## Task 2: WA points (pure, ported from calc_points.py)
+
+**Files:**
+- Create: `st-scrape/curate/__init__.py` (empty)
+- Create: `st-scrape/curate/points.py`
+- Test: `st-scrape/tests/test_curate_points.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `st-scrape/tests/test_curate_points.py`:
+
+```python
+"""WA points: formula, stroke mapping, scorability, season vs fixed reference."""
+from curate import points
+
+
+def _table():
+    # (season, course, gender, relay_count, distance, stroke) -> basetime_sec
+    return {
+        (2022, "LCM", "F", 1, 100, "FREE"): 51.71,
+        (2026, "LCM", "F", 1, 100, "FREE"): 50.00,
+    }
+
+
+def test_formula_truncates():
+    # 1000 * (51.71/51.71)**3 == 1000 exactly.
+    assert points.calculate_points(51.71, 51.71) == 1000
+    # Slower swim scores < 1000.
+    assert points.calculate_points(51.71, 60.00) == 639
+
+
+def test_stroke_mapping_im_and_holdmedley_to_medley():
+    assert points.STROKE_MAP["IM"] == "MEDLEY"
+    assert points.STROKE_MAP["HM"] == "MEDLEY"
+    assert points.STROKE_MAP["Fri"] == "FREE"
+
+
+def test_points_for_uses_season_and_fixed_reference():
+    table = _table()
+    race = {"gender": "F", "relay_count": 1, "distance": 100, "stroke": "Fri"}
+    # season 2022 base 51.71 vs a 52.00 swim.
+    assert points.points_for(table, 2022, "LCM", race, 52.00) == 983
+    # fixed reference season 2026 base 50.00 vs the same swim.
+    assert points.points_for(table, 2026, "LCM", race, 52.00) == 888
+
+
+def test_points_for_returns_none_when_no_base_time():
+    table = _table()
+    race = {"gender": "M", "relay_count": 1, "distance": 100, "stroke": "Fri"}
+    assert points.points_for(table, 2022, "LCM", race, 50.0) is None
+
+
+def test_score_result_skips_dq_and_para_and_missing_time():
+    table = _table()
+    race = {"gender": "F", "relay_count": 1, "distance": 100, "stroke": "Fri"}
+    # Normal scorable swim (open).
+    p, pf = points.score_result(table, 2022, "LCM", race, klass="open",
+                                completed_centiseconds=5200, rank=1)
+    assert (p, pf) == (983, 888)
+    # DQ (rank -1) -> not scored.
+    assert points.score_result(table, 2022, "LCM", race, klass="open",
+                               completed_centiseconds=5200, rank=-1) == (None, None)
+    # Missing time -> not scored.
+    assert points.score_result(table, 2022, "LCM", race, klass="open",
+                               completed_centiseconds=None, rank=1) == (None, None)
+    # Para -> never scored even with a valid time.
+    assert points.score_result(table, 2022, "LCM", race, klass="para",
+                               completed_centiseconds=5200, rank=1) == (None, None)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_points.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'curate'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create empty `st-scrape/curate/__init__.py`. Create `st-scrape/curate/points.py`:
+
+```python
+"""World Aquatics points (pure). Ported from calc_points.py.
+
+points = trunc(1000 * (basetime / swimtime) ** 3).
+Two scores per result:
+  points        - vs the meet's OWN season base times (era-relative).
+  points_fixed  - vs FIXED_REF_SEASON (one stationary cross-era scale).
+"""
+import math
+
+FIXED_REF_SEASON = 2026
+
+# Danish scraper stroke codes -> base-time stroke codes. IM (individual medley)
+# and HM (holdmedley / team medley relay) both map to MEDLEY.
+STROKE_MAP = {"Fri": "FREE", "Ryg": "BACK", "Bryst": "BREAST", "Fly": "FLY",
+              "IM": "MEDLEY", "HM": "MEDLEY"}
+
+
+def calculate_points(basetime_sec, swimtime_sec):
+    """WA points, truncated to an integer."""
+    return math.trunc(1000 * math.pow(basetime_sec / swimtime_sec, 3))
+
+
+def points_for(table, season, course, race, swimtime_sec):
+    """Look up the base time for this race+season and score it, or None."""
+    stroke = STROKE_MAP.get(race.get("stroke"))
+    if stroke is None:
+        return None
+    base = table.get((season, course, race["gender"], race["relay_count"],
+                      race["distance"], stroke))
+    if base is None:
+        return None
+    return calculate_points(base, swimtime_sec)
+
+
+def score_result(table, season, course, race, *, klass,
+                 completed_centiseconds, rank):
+    """Return (points, points_fixed). Para, DQ (rank -1), and missing-time
+    results are never scored."""
+    if klass == "para" or completed_centiseconds is None or rank == -1:
+        return (None, None)
+    t = completed_centiseconds / 100.0
+    return (points_for(table, season, course, race, t),
+            points_for(table, FIXED_REF_SEASON, course, race, t))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_points.py -v`
+Expected: PASS (5 tests). If `calculate_points(51.71, 60.00)` differs, recompute the expected constant from the formula and update the test — the formula is authoritative.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add st-scrape/curate/__init__.py st-scrape/curate/points.py st-scrape/tests/test_curate_points.py
+git commit -m "feat: add pure WA points module for curated zone"
+```
+
+---
+
+## Task 3: Authoritative class resolution
+
+**Files:**
+- Create: `st-scrape/curate/classify.py`
+- Test: `st-scrape/tests/test_curate_classify.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `st-scrape/tests/test_curate_classify.py`:
+
+```python
+"""Authoritative class = per-(meet,race) override if present, else the raw
+Timed-final-duplicating-a-prelim/final heuristic."""
+from curate import classify
+
+
+def _race(race_id, name, rtype):
+    return {"race_id": race_id, "name": name, "type": rtype}
+
+
+def test_heuristic_marks_timed_final_duplicate_as_para():
+    races = [
+        _race(1, "100 Fri - Damer", "Heats"),
+        _race(2, "100 Fri - Damer", "Final"),
+        _race(3, "100 Fri - Damer", "Timed final"),  # para: duplicates a prelim/final
+        _race(4, "800 Fri - Damer", "Timed final"),   # open: no prelim/final twin
+    ]
+    resolved = classify.authoritative_class(races, overrides={})
+    assert resolved == {1: "open", 2: "open", 3: "para", 4: "open"}
+
+
+def test_override_wins_over_heuristic():
+    races = [_race(9, "50 Fri - Herrer", "Timed final")]  # heuristic -> open
+    resolved = classify.authoritative_class(races, overrides={9: "para"})
+    assert resolved == {9: "para"}
+
+
+def test_override_can_force_open():
+    races = [
+        _race(1, "100 Fri - Damer", "Heats"),
+        _race(2, "100 Fri - Damer", "Final"),
+        _race(3, "100 Fri - Damer", "Timed final"),  # heuristic -> para
+    ]
+    resolved = classify.authoritative_class(races, overrides={3: "open"})
+    assert resolved[3] == "open"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_classify.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'curate.classify'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `st-scrape/curate/classify.py`:
+
+```python
+"""Authoritative open/para class for curated races.
+
+Override-else-heuristic. The heuristic mirrors the raw zone's rule: a 'Timed
+final' whose event name also appears as a Heats/Final in the same meet is a para
+event (an able-bodied direct final has no prelim/final twin)."""
+
+
+def authoritative_class(races, overrides):
+    """races: list of dicts with race_id, name, type. overrides: {race_id: class}.
+    Returns {race_id: 'open'|'para'}."""
+    prelim_final_names = {r["name"] for r in races
+                          if r.get("type") in ("Heats", "Final")}
+    resolved = {}
+    for r in races:
+        rid = r["race_id"]
+        if rid in overrides:
+            resolved[rid] = overrides[rid]
+            continue
+        is_para = r.get("type") == "Timed final" and r.get("name") in prelim_final_names
+        resolved[rid] = "para" if is_para else "open"
+    return resolved
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_classify.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add st-scrape/curate/classify.py st-scrape/tests/test_curate_classify.py
+git commit -m "feat: add authoritative class resolution (override-else-heuristic)"
+```
+
+---
+
+## Task 4: Build curated rows from raw (model)
+
+**Files:**
+- Create: `st-scrape/curate/model.py`
+- Test: `st-scrape/tests/test_curate_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `st-scrape/tests/test_curate_model.py`:
+
+```python
+"""Row builders: dim_meet, dim_race, fact_result (+ result_id, points),
+fact_split, obt_result."""
+from curate import model
+
+MEET = {"meet_id": 8609, "meet": "DM Langbane 2021", "venue": "Aarhus",
+        "course": "LCM", "season": 2021, "date": "08-07-2021",
+        "category": ["DM-L", "DMJ-L"]}
+
+RACES = [
+    {"meet_id": 8609, "race_id": 1, "number": 1, "name": "100 Fri - Damer",
+     "distance": 100, "stroke": "Fri", "gender": "F", "relay_count": 1,
+     "type": "Final", "class": "open"},
+]
+
+RESULTS = [
+    {"race_id": 1, "Rank": 1, "Name": "A B", "Swimmer_id": "7", "nationality": "DK",
+     "club": "C", "birth_year": 2001, "completed_time": "1:00.00",
+     "completed_centiseconds": 6000,
+     "splits": [{"distance": 50, "split_time": "29.00", "split_centiseconds": 2900,
+                 "cumulative_time": "29.00", "cumulative_centiseconds": 2900}]},
+    {"race_id": 1, "Rank": -1, "Name": "DQ One", "Swimmer_id": "8", "nationality": "DK",
+     "club": "C", "birth_year": 2002, "completed_time": "DQ",
+     "completed_centiseconds": None, "splits": []},
+    {"race_id": 1, "Rank": -1, "Name": "DQ Two", "Swimmer_id": "9", "nationality": "DK",
+     "club": "C", "birth_year": 2003, "completed_time": "DQ",
+     "completed_centiseconds": None, "splits": []},
+]
+
+
+def test_dim_meet_row():
+    row = model.build_dim_meet(MEET)
+    assert row == {"meet_id": "8609", "meet_name": "DM Langbane 2021",
+                   "venue": "Aarhus", "course": "LCM", "season": 2021,
+                   "meet_date": "08-07-2021", "category": ["DM-L", "DMJ-L"]}
+
+
+def test_dim_race_carries_authoritative_class_and_partitions():
+    rows = model.build_dim_race(RACES, {1: "para"}, season=2021, course="LCM")
+    assert rows[0]["class"] == "para"
+    assert rows[0]["season"] == 2021 and rows[0]["course"] == "LCM"
+    assert rows[0]["race_id"] == 1 and rows[0]["meet_id"] == "8609"
+
+
+def test_result_id_uses_ordinal_not_rank_so_dqs_dont_collide():
+    table = {(2021, "LCM", "F", 1, 100, "FREE"): 60.0}
+    races_by_id = {1: RACES[0]}
+    rows = model.build_fact_result(RESULTS, races_by_id, {1: "open"}, table,
+                                   meet_id="8609", season=2021, course="LCM")
+    ids = [r["result_id"] for r in rows]
+    assert ids == ["1-0", "1-1", "1-2"]   # two DQs do NOT collide
+    # First row scored (base 60.0 vs 60.0 swim -> 1000); DQs unscored.
+    assert rows[0]["points"] == 1000 and rows[0]["points_fixed"] is None
+    assert rows[1]["points"] is None and rows[2]["points"] is None
+    assert rows[0]["rank"] == 1 and rows[0]["swimmer_id"] == "7"
+
+
+def test_fact_split_keys_to_result_id():
+    rows = model.build_fact_split(RESULTS, meet_id="8609", season=2021, course="LCM")
+    assert len(rows) == 1                 # only the first result has splits
+    assert rows[0]["result_id"] == "1-0"
+    assert rows[0]["distance"] == 50 and rows[0]["split_centiseconds"] == 2900
+
+
+def test_obt_inlines_meet_and_race_attributes():
+    table = {(2021, "LCM", "F", 1, 100, "FREE"): 60.0}
+    races_by_id = {1: RACES[0]}
+    fact = model.build_fact_result(RESULTS, races_by_id, {1: "open"}, table,
+                                   meet_id="8609", season=2021, course="LCM")
+    obt = model.build_obt(fact, MEET, races_by_id, {1: "open"})
+    assert obt[0]["meet_name"] == "DM Langbane 2021"
+    assert obt[0]["race_name"] == "100 Fri - Damer"
+    assert obt[0]["stroke"] == "Fri" and obt[0]["class"] == "open"
+    assert obt[0]["result_id"] == "1-0" and obt[0]["points"] == 1000
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_model.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'curate.model'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `st-scrape/curate/model.py`:
+
+```python
+"""Build curated table rows from raw meet/race/result dicts.
+
+result_id is race-local ordinal (f"{race_id}-{i}"), NOT Rank: disqualified swims
+share Rank=-1 and would collide. Raw file order is deterministic, so ordinals are
+stable across re-runs."""
+from curate import points as points_mod
+
+
+def build_dim_meet(meet):
+    return {
+        "meet_id": str(meet["meet_id"]),
+        "meet_name": meet.get("meet", ""),
+        "venue": meet.get("venue", ""),
+        "course": meet["course"],
+        "season": meet["season"],
+        "meet_date": meet.get("date", ""),
+        "category": list(meet.get("category", [])),
+    }
+
+
+def build_dim_race(races, class_by_id, *, season, course):
+    rows = []
+    for r in races:
+        rows.append({
+            "race_id": r["race_id"],
+            "meet_id": str(r["meet_id"]),
+            "number": r.get("number"),
+            "name": r["name"],
+            "distance": r["distance"],
+            "stroke": r["stroke"],
+            "gender": r["gender"],
+            "relay_count": r["relay_count"],
+            "type": r["type"],
+            "class": class_by_id[r["race_id"]],
+            "season": season,
+            "course": course,
+        })
+    return rows
+
+
+def _result_ids(results):
+    """Assign race-local ordinal ids in raw file order."""
+    counters, ids = {}, []
+    for r in results:
+        rid = r["race_id"]
+        i = counters.get(rid, 0)
+        ids.append(f"{rid}-{i}")
+        counters[rid] = i + 1
+    return ids
+
+
+def build_fact_result(results, races_by_id, class_by_id, base_times, *,
+                      meet_id, season, course):
+    ids = _result_ids(results)
+    rows = []
+    for result_id, r in zip(ids, results):
+        race = races_by_id.get(r["race_id"])
+        cs = r.get("completed_centiseconds")
+        if race is None:
+            p = pf = None
+        else:
+            p, pf = points_mod.score_result(
+                base_times, season, course, race,
+                klass=class_by_id.get(r["race_id"], "open"),
+                completed_centiseconds=cs, rank=r.get("Rank"))
+        rows.append({
+            "result_id": result_id,
+            "race_id": r["race_id"],
+            "meet_id": str(meet_id),
+            "rank": r.get("Rank"),
+            "name": r.get("Name", ""),
+            "swimmer_id": r.get("Swimmer_id"),
+            "nationality": r.get("nationality"),
+            "club": r.get("club"),
+            "birth_year": r.get("birth_year"),
+            "completed_time": r.get("completed_time"),
+            "completed_centiseconds": cs,
+            "points": p,
+            "points_fixed": pf,
+            "season": season,
+            "course": course,
+        })
+    return rows
+
+
+def build_fact_split(results, *, meet_id, season, course):
+    ids = _result_ids(results)
+    rows = []
+    for result_id, r in zip(ids, results):
+        for s in r.get("splits", []):
+            rows.append({
+                "result_id": result_id,
+                "race_id": r["race_id"],
+                "distance": s.get("distance"),
+                "split_time": s.get("split_time"),
+                "split_centiseconds": s.get("split_centiseconds"),
+                "cumulative_time": s.get("cumulative_time"),
+                "cumulative_centiseconds": s.get("cumulative_centiseconds"),
+                "season": season,
+                "course": course,
+            })
+    return rows
+
+
+def build_obt(fact_result_rows, meet, races_by_id, class_by_id):
+    rows = []
+    for fr in fact_result_rows:
+        race = races_by_id.get(fr["race_id"], {})
+        row = dict(fr)
+        row.update({
+            "meet_name": meet.get("meet", ""),
+            "venue": meet.get("venue", ""),
+            "meet_date": meet.get("date", ""),
+            "number": race.get("number"),
+            "race_name": race.get("name"),
+            "distance": race.get("distance"),
+            "stroke": race.get("stroke"),
+            "gender": race.get("gender"),
+            "relay_count": race.get("relay_count"),
+            "type": race.get("type"),
+            "class": class_by_id.get(fr["race_id"], "open"),
+        })
+        rows.append(row)
+    return rows
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_model.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add st-scrape/curate/model.py st-scrape/tests/test_curate_model.py
+git commit -m "feat: add curated row builders with ordinal result_id"
+```
+
+---
+
+## Task 5: Pure transform_meet orchestration
+
+**Files:**
+- Create: `st-scrape/curate/transform.py`
+- Test: `st-scrape/tests/test_curate_transform.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `st-scrape/tests/test_curate_transform.py`:
+
+```python
+"""transform_meet ties model builders together from parsed raw dicts."""
+from curate import transform
+
+MEET = {"meet_id": 8609, "meet": "DM L 2021", "venue": "Aarhus", "course": "LCM",
+        "season": 2021, "date": "08-07-2021", "category": ["DM-L"]}
+RACES = [
+    {"meet_id": 8609, "race_id": 1, "number": 1, "name": "100 Fri - Damer",
+     "distance": 100, "stroke": "Fri", "gender": "F", "relay_count": 1,
+     "type": "Final", "class": "open"},
+    {"meet_id": 8609, "race_id": 2, "number": 2, "name": "100 Fri - Damer",
+     "distance": 100, "stroke": "Fri", "gender": "F", "relay_count": 1,
+     "type": "Timed final", "class": "open"},   # para by heuristic (dup of race 1)
+]
+RESULTS = [
+    {"race_id": 1, "Rank": 1, "Name": "A", "Swimmer_id": "7", "completed_time": "1:00.00",
+     "completed_centiseconds": 6000, "splits": []},
+    {"race_id": 2, "Rank": 1, "Name": "P", "Swimmer_id": "8", "completed_time": "1:10.00",
+     "completed_centiseconds": 7000, "splits": []},
+]
+
+
+def test_transform_produces_all_tables_and_para_is_unscored():
+    base_times = {(2021, "LCM", "F", 1, 100, "FREE"): 60.0}
+    tables = transform.transform_meet(MEET, RACES, RESULTS, base_times, overrides={})
+    assert set(tables) == {"dim_meet", "dim_race", "fact_result", "fact_split", "obt_result"}
+    assert len(tables["dim_meet"]) == 1
+    # Race 2 is para (Timed final duplicating race 1's name) -> dim_race says so.
+    race_class = {r["race_id"]: r["class"] for r in tables["dim_race"]}
+    assert race_class == {1: "open", 2: "para"}
+    # Open result scored, para result unscored.
+    pts = {r["race_id"]: r["points"] for r in tables["fact_result"]}
+    assert pts[1] == 1000 and pts[2] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_transform.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'curate.transform'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `st-scrape/curate/transform.py`:
+
+```python
+"""Pure curated transform: parsed raw dicts -> {table_name: [row dicts]}."""
+from curate import classify, model
+
+
+def transform_meet(meet, races, results, base_times, overrides):
+    """meet: dict. races/results: lists of dicts. base_times: lookup table.
+    overrides: {race_id: 'open'|'para'}. Returns the five curated tables."""
+    season, course = meet["season"], meet["course"]
+    class_by_id = classify.authoritative_class(races, overrides)
+    races_by_id = {r["race_id"]: r for r in races}
+
+    fact_result = model.build_fact_result(
+        results, races_by_id, class_by_id, base_times,
+        meet_id=meet["meet_id"], season=season, course=course)
+
+    return {
+        "dim_meet": [model.build_dim_meet(meet)],
+        "dim_race": model.build_dim_race(races, class_by_id, season=season, course=course),
+        "fact_result": fact_result,
+        "fact_split": model.build_fact_split(
+            results, meet_id=meet["meet_id"], season=season, course=course),
+        "obt_result": model.build_obt(fact_result, meet, races_by_id, class_by_id),
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_transform.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add st-scrape/curate/transform.py st-scrape/tests/test_curate_transform.py
+git commit -m "feat: add pure transform_meet orchestration"
+```
+
+---
+
+## Task 6: Parquet schemas + writer + partition paths
+
+**Files:**
+- Create: `st-scrape/curate/parquet.py`
+- Test: `st-scrape/tests/test_curate_parquet.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `st-scrape/tests/test_curate_parquet.py`:
+
+```python
+"""Parquet writer: round-trips rows, handles nulls, and builds partition paths."""
+import io
+
+import pyarrow.parquet as pq
+
+from curate import parquet
+
+
+def test_partition_path_per_meet():
+    assert parquet.object_key("fact_result", season=2021, course="LCM", meet_id="8609") == \
+        "curated/fact_result/season=2021/course=LCM/meet=8609.parquet"
+
+
+def test_write_round_trips_with_nulls():
+    rows = [
+        {"result_id": "1-0", "points": 1000, "points_fixed": None,
+         "season": 2021, "course": "LCM"},
+        {"result_id": "1-1", "points": None, "points_fixed": None,
+         "season": 2021, "course": "LCM"},
+    ]
+    data = parquet.write_parquet_bytes("fact_result", rows)
+    table = pq.read_table(io.BytesIO(data))
+    out = table.to_pylist()
+    assert out[0]["result_id"] == "1-0" and out[0]["points"] == 1000
+    assert out[1]["points"] is None
+
+
+def test_empty_rows_still_writes_valid_schema():
+    data = parquet.write_parquet_bytes("fact_split", [])
+    table = pq.read_table(io.BytesIO(data))
+    assert table.num_rows == 0
+    assert "result_id" in table.schema.names
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_parquet.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'curate.parquet'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `st-scrape/curate/parquet.py`:
+
+```python
+"""Parquet schemas + writer + S3 object keys for the curated zone.
+
+Explicit pyarrow schemas (not inferred) so an empty meet still writes a
+well-typed file and the Glue catalog stays stable."""
+import io
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+_S = pa.string()
+_I = pa.int64()
+
+SCHEMAS = {
+    "dim_meet": pa.schema([
+        ("meet_id", _S), ("meet_name", _S), ("venue", _S), ("course", _S),
+        ("season", _I), ("meet_date", _S), ("category", pa.list_(_S)),
+    ]),
+    "dim_race": pa.schema([
+        ("race_id", _I), ("meet_id", _S), ("number", _I), ("name", _S),
+        ("distance", _I), ("stroke", _S), ("gender", _S), ("relay_count", _I),
+        ("type", _S), ("class", _S), ("season", _I), ("course", _S),
+    ]),
+    "fact_result": pa.schema([
+        ("result_id", _S), ("race_id", _I), ("meet_id", _S), ("rank", _I),
+        ("name", _S), ("swimmer_id", _S), ("nationality", _S), ("club", _S),
+        ("birth_year", _I), ("completed_time", _S), ("completed_centiseconds", _I),
+        ("points", _I), ("points_fixed", _I), ("season", _I), ("course", _S),
+    ]),
+    "fact_split": pa.schema([
+        ("result_id", _S), ("race_id", _I), ("distance", _I), ("split_time", _S),
+        ("split_centiseconds", _I), ("cumulative_time", _S),
+        ("cumulative_centiseconds", _I), ("season", _I), ("course", _S),
+    ]),
+    "obt_result": pa.schema([
+        ("result_id", _S), ("race_id", _I), ("meet_id", _S), ("rank", _I),
+        ("name", _S), ("swimmer_id", _S), ("nationality", _S), ("club", _S),
+        ("birth_year", _I), ("completed_time", _S), ("completed_centiseconds", _I),
+        ("points", _I), ("points_fixed", _I), ("season", _I), ("course", _S),
+        ("meet_name", _S), ("venue", _S), ("meet_date", _S), ("number", _I),
+        ("race_name", _S), ("distance", _I), ("stroke", _S), ("gender", _S),
+        ("relay_count", _I), ("type", _S), ("class", _S),
+    ]),
+}
+
+
+def object_key(table, *, season, course, meet_id):
+    return (f"curated/{table}/season={season}/course={course}/"
+            f"meet={meet_id}.parquet")
+
+
+def write_parquet_bytes(table, rows):
+    """Serialize rows to Snappy Parquet bytes using the table's fixed schema.
+    Missing keys become nulls; extra keys are ignored."""
+    schema = SCHEMAS[table]
+    columns = {name: [row.get(name) for row in rows] for name in schema.names}
+    arrays = [pa.array(columns[name], type=field.type)
+              for name, field in zip(schema.names, schema)]
+    arrow_table = pa.table(arrays, schema=schema)
+    buf = io.BytesIO()
+    pq.write_table(arrow_table, buf, compression="snappy")
+    return buf.getvalue()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_parquet.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add st-scrape/curate/parquet.py st-scrape/tests/test_curate_parquet.py
+git commit -m "feat: add curated Parquet schemas, writer, and object keys"
+```
+
+---
+
+## Task 7: Class-overrides DynamoDB access layer
+
+**Files:**
+- Create: `st-scrape/curate/overrides.py`
+- Test: `st-scrape/tests/test_curate_overrides.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `st-scrape/tests/test_curate_overrides.py`:
+
+```python
+"""Class-overrides table: set/list/get-for-meet."""
+import boto3
+import pytest
+
+from curate.overrides import ClassOverrides
+
+REGION = "eu-west-1"
+TABLE = "swimtrends-class-overrides-test"
+
+
+@pytest.fixture
+def overrides_table(mocked_aws):
+    ddb = boto3.resource("dynamodb", region_name=REGION)
+    ddb.create_table(
+        TableName=TABLE,
+        KeySchema=[{"AttributeName": "meet_id", "KeyType": "HASH"},
+                   {"AttributeName": "race_id", "KeyType": "RANGE"}],
+        AttributeDefinitions=[{"AttributeName": "meet_id", "AttributeType": "S"},
+                              {"AttributeName": "race_id", "AttributeType": "N"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    yield ddb.Table(TABLE)
+
+
+def test_set_then_get_for_meet_returns_race_id_to_class(overrides_table):
+    ov = ClassOverrides(TABLE, region=REGION)
+    ov.set_override("8609", 213, "para", reason="para-only event")
+    ov.set_override("8609", 99, "open", reason="false positive")
+    ov.set_override("9999", 1, "para", reason="other meet")
+    assert ov.get_for_meet("8609") == {213: "para", 99: "open"}
+
+
+def test_get_for_meet_empty_when_none(overrides_table):
+    ov = ClassOverrides(TABLE, region=REGION)
+    assert ov.get_for_meet("8609") == {}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_overrides.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'curate.overrides'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `st-scrape/curate/overrides.py`:
+
+```python
+"""DynamoDB access for per-(meet,race) authoritative class overrides.
+
+Partition key meet_id (S), sort key race_id (N). Sparse: only the handful of
+races the heuristic gets wrong."""
+import boto3
+from boto3.dynamodb.conditions import Key
+
+
+class ClassOverrides:
+    def __init__(self, table_name, region=None):
+        self._table = boto3.resource("dynamodb", region_name=region).Table(table_name)
+
+    def set_override(self, meet_id, race_id, klass, reason=""):
+        if klass not in ("open", "para"):
+            raise ValueError(f"class must be 'open' or 'para', got {klass!r}")
+        self._table.put_item(Item={
+            "meet_id": str(meet_id), "race_id": int(race_id),
+            "class": klass, "reason": reason,
+        })
+
+    def get_for_meet(self, meet_id):
+        """Return {race_id(int): class} for one meet."""
+        resp = self._table.query(
+            KeyConditionExpression=Key("meet_id").eq(str(meet_id)))
+        return {int(i["race_id"]): i["class"] for i in resp.get("Items", [])}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_overrides.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add st-scrape/curate/overrides.py st-scrape/tests/test_curate_overrides.py
+git commit -m "feat: add class-overrides DynamoDB access layer"
+```
+
+---
+
+## Task 8: Base-times loader (from S3 or local file)
+
+**Files:**
+- Create: `st-scrape/curate/basetimes.py`
+- Test: `st-scrape/tests/test_curate_basetimes.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `st-scrape/tests/test_curate_basetimes.py`:
+
+```python
+"""Base-times loader parses JSONL into the (season,course,gender,relay,dist,stroke)
+-> seconds lookup the points module expects."""
+from curate import basetimes
+
+JSONL = (
+    '{"season": 2022, "course": "LCM", "gender": "F", "relay_count": 1, '
+    '"distance": 100, "stroke": "FREE", "basetime": "51.71", "basetime_in_sec": 51.71}\n'
+    '{"season": 2026, "course": "LCM", "gender": "F", "relay_count": 1, '
+    '"distance": 100, "stroke": "FREE", "basetime": "50.00", "basetime_in_sec": 50.0}\n'
+)
+
+
+def test_parse_jsonl_to_lookup():
+    table = basetimes.parse(JSONL)
+    assert table[(2022, "LCM", "F", 1, 100, "FREE")] == 51.71
+    assert table[(2026, "LCM", "F", 1, 100, "FREE")] == 50.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_basetimes.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'curate.basetimes'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `st-scrape/curate/basetimes.py`:
+
+```python
+"""Load the WA base-times reference into the lookup the points module uses.
+
+Keyed (season, course, gender, relay_count, distance, stroke) -> seconds."""
+import json
+
+
+def parse(jsonl_text):
+    table = {}
+    for line in jsonl_text.splitlines():
+        if not line.strip():
+            continue
+        r = json.loads(line)
+        table[(r["season"], r["course"], r["gender"], r["relay_count"],
+               r["distance"], r["stroke"])] = r["basetime_in_sec"]
+    return table
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_basetimes.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add st-scrape/curate/basetimes.py st-scrape/tests/test_curate_basetimes.py
+git commit -m "feat: add base-times JSONL loader for curated points"
+```
+
+---
+
+## Task 9: run_curate_task orchestration (injected I/O) + main
+
+**Files:**
+- Create: `st-scrape/curate/run.py`
+- Test: `st-scrape/tests/test_curate_run.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `st-scrape/tests/test_curate_run.py`:
+
+```python
+"""run_curate_task: read raw -> transform -> write curated parquet -> notify.
+All I/O injected; verifies object keys, overwrite-by-meet, and notification."""
+import io
+
+import pyarrow.parquet as pq
+
+from curate import run
+
+MEET = ('{"meet_id": 8609, "meet": "DM L 2021", "venue": "Aarhus", '
+        '"course": "LCM", "season": 2021, "date": "08-07-2021", "category": ["DM-L"]}')
+RACES = (
+    '{"meet_id": 8609, "race_id": 1, "number": 1, "name": "100 Fri - Damer", '
+    '"distance": 100, "stroke": "Fri", "gender": "F", "relay_count": 1, '
+    '"type": "Final", "class": "open"}\n'
+)
+RESULTS = (
+    '{"race_id": 1, "Rank": 1, "Name": "A", "Swimmer_id": "7", '
+    '"completed_time": "1:00.00", "completed_centiseconds": 6000, "splits": []}\n'
+)
+BASE_TIMES = ('{"season": 2021, "course": "LCM", "gender": "F", "relay_count": 1, '
+              '"distance": 100, "stroke": "FREE", "basetime_in_sec": 60.0}\n')
+
+
+def test_run_writes_all_five_tables_and_notifies():
+    raw = {
+        "raw/meet=8609/meet_info.jsonl": MEET,
+        "raw/meet=8609/races.jsonl": RACES,
+        "raw/meet=8609/results.jsonl": RESULTS,
+        "reference/point_base_times.jsonl": BASE_TIMES,
+    }
+    written, notes = {}, []
+
+    run.run_curate_task(
+        meet_id="8609",
+        read_text=lambda key: raw[key],
+        get_overrides=lambda mid: {},
+        write_bytes=lambda key, data: written.__setitem__(key, data),
+        notify=lambda subject, msg: notes.append(subject),
+    )
+
+    assert set(written) == {
+        "curated/dim_meet/season=2021/course=LCM/meet=8609.parquet",
+        "curated/dim_race/season=2021/course=LCM/meet=8609.parquet",
+        "curated/fact_result/season=2021/course=LCM/meet=8609.parquet",
+        "curated/fact_split/season=2021/course=LCM/meet=8609.parquet",
+        "curated/obt_result/season=2021/course=LCM/meet=8609.parquet",
+    }
+    fr = pq.read_table(io.BytesIO(
+        written["curated/fact_result/season=2021/course=LCM/meet=8609.parquet"]))
+    assert fr.to_pylist()[0]["points"] == 1000
+    assert any("curat" in s.lower() for s in notes)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_run.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'curate.run'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `st-scrape/curate/run.py`:
+
+```python
+"""Curated transform task entrypoint.
+
+run_curate_task() is pure-ish orchestration with all I/O injected (read_text,
+get_overrides, write_bytes, notify) so it unit-tests without AWS. main() wires
+the real boto3 implementations and is the Fargate container entry."""
+import json
+import os
+
+from curate import basetimes, parquet, transform
+
+RAW_PREFIX = "raw/meet={meet_id}/"
+BASE_TIMES_KEY = "reference/point_base_times.jsonl"
+
+
+def _read_jsonl(read_text, key):
+    return [json.loads(l) for l in read_text(key).splitlines() if l.strip()]
+
+
+def run_curate_task(*, meet_id, read_text, get_overrides, write_bytes, notify):
+    """Transform one meet's raw zone into curated Parquet. Re-raises on failure
+    after notifying, so the container exits non-zero."""
+    try:
+        prefix = RAW_PREFIX.format(meet_id=meet_id)
+        meet = _read_jsonl(read_text, prefix + "meet_info.jsonl")[0]
+        races = _read_jsonl(read_text, prefix + "races.jsonl")
+        results = _read_jsonl(read_text, prefix + "results.jsonl")
+        base_times = basetimes.parse(read_text(BASE_TIMES_KEY))
+        overrides = get_overrides(meet_id)
+
+        tables = transform.transform_meet(meet, races, results, base_times, overrides)
+        season, course = meet["season"], meet["course"]
+        counts = {}
+        for table_name, rows in tables.items():
+            key = parquet.object_key(table_name, season=season, course=course,
+                                     meet_id=meet_id)
+            write_bytes(key, parquet.write_parquet_bytes(table_name, rows))
+            counts[table_name] = len(rows)
+
+        notify("Swimtrends curate SUCCEEDED",
+               f"Meet {meet_id} ({meet.get('meet','')}) curated: {counts}")
+        return counts
+    except Exception as e:
+        notify("Swimtrends curate FAILED", f"Meet {meet_id}: {e}")
+        raise
+
+
+def main():
+    import boto3
+
+    from curate.overrides import ClassOverrides
+
+    meet_id = os.environ["MEET_ID"]
+    bucket = os.environ["CURATED_BUCKET"]
+    topic_arn = os.environ["SNS_TOPIC_ARN"]
+    overrides = ClassOverrides(os.environ["OVERRIDES_TABLE"])
+
+    s3 = boto3.client("s3")
+    sns = boto3.client("sns")
+
+    def read_text(key):
+        return s3.get_object(Bucket=bucket, Key=key)["Body"].read().decode("utf-8")
+
+    def write_bytes(key, data):
+        s3.put_object(Bucket=bucket, Key=key, Body=data)
+
+    run_curate_task(
+        meet_id=meet_id,
+        read_text=read_text,
+        get_overrides=overrides.get_for_meet,
+        write_bytes=write_bytes,
+        notify=lambda subject, msg: sns.publish(
+            TopicArn=topic_arn, Subject=subject[:100], Message=msg),
+    )
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_run.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite to confirm no regressions**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest -q`
+Expected: all green (Spec 1 suite + new curate tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add st-scrape/curate/run.py st-scrape/tests/test_curate_run.py
+git commit -m "feat: add run_curate_task orchestration and container main"
+```
+
+---
+
+## Task 10: CLI subcommands (curate, class, basetimes)
+
+**Files:**
+- Modify: `st-scrape/ingestion/cli.py`
+- Test: `st-scrape/tests/test_cli_curate.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `st-scrape/tests/test_cli_curate.py`:
+
+```python
+"""CLI curate/class subcommands route to the right injected side effects."""
+from ingestion import cli
+
+
+class FakeRegistry:
+    def __init__(self, ids):
+        self._ids = ids
+
+    def scheduled_meets(self):  # unused here but matches interface
+        return []
+
+    def all_meet_ids(self):
+        return self._ids
+
+
+class FakeOverrides:
+    def __init__(self):
+        self.calls = []
+
+    def set_override(self, meet_id, race_id, klass, reason=""):
+        self.calls.append((meet_id, race_id, klass, reason))
+
+
+def test_curate_single_meet_invokes_curator():
+    invoked = []
+    cli.run(["curate", "8609"], registry=None, invoke=None,
+            curate=lambda payload: invoked.append(payload), overrides=None)
+    assert invoked == [{"meet_ids": ["8609"]}]
+
+
+def test_curate_all_invokes_with_all_flag():
+    invoked = []
+    cli.run(["curate", "--all"], registry=None, invoke=None,
+            curate=lambda payload: invoked.append(payload), overrides=None)
+    assert invoked == [{"all": True}]
+
+
+def test_class_set_writes_override():
+    ov = FakeOverrides()
+    cli.run(["class", "set", "8609", "213", "para", "--reason", "para-only"],
+            registry=None, invoke=None, curate=None, overrides=ov)
+    assert ov.calls == [("8609", 213, "para", "para-only")]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_cli_curate.py -v`
+Expected: FAIL — `run()` does not accept `curate`/`overrides` kwargs.
+
+- [ ] **Step 3: Extend the CLI**
+
+In `st-scrape/ingestion/cli.py`, add parsers inside `build_parser()` (after the `disp` parser, before `return parser`):
+
+```python
+    cur = sub.add_parser("curate", help="Run the curated transform.")
+    cur.add_argument("meet_id", nargs="?", default=None)
+    cur.add_argument("--all", action="store_true",
+                     help="Curate every meet (full rebuild).")
+
+    cls = sub.add_parser("class", help="Manage authoritative class overrides.")
+    cls_sub = cls.add_subparsers(dest="class_command", required=True)
+    cls_set = cls_sub.add_parser("set", help="Set an override for one race.")
+    cls_set.add_argument("meet_id")
+    cls_set.add_argument("race_id", type=int)
+    cls_set.add_argument("klass", choices=["open", "para"])
+    cls_set.add_argument("--reason", default="")
+```
+
+Change the `run()` signature and add the new branches. Replace
+`def run(argv, *, registry, invoke):` with:
+
+```python
+def run(argv, *, registry, invoke, curate=None, overrides=None):
+    """Execute one CLI command. registry/invoke/curate/overrides injected."""
+```
+
+Then, before the final implicit return of `run()`, add:
+
+```python
+    if args.command == "curate":
+        if args.all and args.meet_id:
+            raise SystemExit("Pass a meet_id OR --all, not both.")
+        payload = {"all": True} if args.all else {"meet_ids": [args.meet_id]}
+        if not args.all and not args.meet_id:
+            raise SystemExit("curate needs a meet_id or --all.")
+        curate(payload)
+        print(f"Curate invoked with payload: {json.dumps(payload)}")
+        return
+
+    if args.command == "class":
+        if args.class_command == "set":
+            overrides.set_override(args.meet_id, args.race_id, args.klass,
+                                   reason=args.reason)
+            print(f"Override set: meet {args.meet_id} race {args.race_id} "
+                  f"-> {args.klass}")
+        return
+```
+
+Update `main()` to construct the new injected dependencies. After the existing
+`lambda_client`/`function_name` setup, add:
+
+```python
+    from curate.overrides import ClassOverrides
+
+    overrides = ClassOverrides(os.environ["OVERRIDES_TABLE"]) \
+        if os.environ.get("OVERRIDES_TABLE") else None
+    curator_fn = os.environ.get("CURATOR_FUNCTION")
+
+    def curate(payload):
+        if curator_fn is None:
+            raise SystemExit("CURATOR_FUNCTION not set.")
+        resp = lambda_client.invoke(
+            FunctionName=curator_fn, InvocationType="Event",
+            Payload=json.dumps(payload).encode("utf-8"))
+        return resp["StatusCode"]
+```
+
+and change the final call to:
+
+```python
+    run(sys.argv[1:], registry=registry, invoke=invoke,
+        curate=curate, overrides=overrides)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_cli_curate.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the existing CLI tests for no regressions**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_cli.py -v`
+Expected: PASS — existing `cli.run(...)` calls still work because `curate`/`overrides` default to `None`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add st-scrape/ingestion/cli.py st-scrape/tests/test_cli_curate.py
+git commit -m "feat: add curate and class CLI subcommands"
+```
+
+---
+
+## Task 11: Glue catalog table definitions
+
+**Files:**
+- Create: `st-scrape/curate/catalog.py`
+- Test: `st-scrape/tests/test_curate_catalog.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `st-scrape/tests/test_curate_catalog.py`:
+
+```python
+"""Glue table input is derived from the same schema, partitioned by season/course."""
+from curate import catalog
+
+
+def test_table_input_has_partition_keys_and_columns():
+    ti = catalog.table_input("fact_result", "s3://bucket/curated/fact_result/")
+    assert ti["Name"] == "fact_result"
+    part_keys = [c["Name"] for c in ti["PartitionKeys"]]
+    assert part_keys == ["season", "course"]
+    col_names = [c["Name"] for c in ti["StorageDescriptor"]["Columns"]]
+    # Partition columns must NOT also appear in Columns (Glue rejects overlap).
+    assert "season" not in col_names and "course" not in col_names
+    assert "result_id" in col_names and "points" in col_names
+    assert ti["StorageDescriptor"]["Location"] == "s3://bucket/curated/fact_result/"
+
+
+def test_all_five_tables_supported():
+    for name in ["dim_meet", "dim_race", "fact_result", "fact_split", "obt_result"]:
+        ti = catalog.table_input(name, f"s3://bucket/curated/{name}/")
+        assert ti["Name"] == name
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_catalog.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'curate.catalog'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `st-scrape/curate/catalog.py`:
+
+```python
+"""Glue Data Catalog table definitions derived from the Parquet schemas.
+
+season/course are partition keys (encoded in the S3 path), so they are declared
+as PartitionKeys and excluded from the regular column list."""
+import pyarrow as pa
+
+from curate import parquet
+
+PARTITION_COLS = ("season", "course")
+
+_ARROW_TO_GLUE = {pa.string(): "string", pa.int64(): "bigint"}
+
+
+def _glue_type(arrow_type):
+    if pa.types.is_list(arrow_type):
+        inner = _ARROW_TO_GLUE[arrow_type.value_type]
+        return f"array<{inner}>"
+    return _ARROW_TO_GLUE[arrow_type]
+
+
+def table_input(table, location):
+    """Return a Glue CreateTable 'TableInput' dict for one curated table."""
+    schema = parquet.SCHEMAS[table]
+    columns = [{"Name": f.name, "Type": _glue_type(f.type)}
+               for f in schema if f.name not in PARTITION_COLS]
+    return {
+        "Name": table,
+        "TableType": "EXTERNAL_TABLE",
+        "Parameters": {"classification": "parquet", "EXTERNAL": "TRUE"},
+        "PartitionKeys": [
+            {"Name": "season", "Type": "bigint"},
+            {"Name": "course", "Type": "string"},
+        ],
+        "StorageDescriptor": {
+            "Columns": columns,
+            "Location": location,
+            "InputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
+            "OutputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+            "SerdeInfo": {
+                "SerializationLibrary":
+                    "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+            },
+        },
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd st-scrape && .venv/bin/python -m pytest tests/test_curate_catalog.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add st-scrape/curate/catalog.py st-scrape/tests/test_curate_catalog.py
+git commit -m "feat: add Glue table definitions for curated tables"
+```
+
+---
+
+## Task 12: Curated container image entrypoint
+
+**Files:**
+- Modify: `st-scrape/Dockerfile`
+- Create: `st-scrape/Dockerfile.curate`
+
+The Spec 1 `Dockerfile` ENTRYPOINT is the scraper. The curated task needs its own
+entrypoint but can share the codebase. Use a dedicated Dockerfile that copies the
+`curate/` package and runs `python -m curate.run`.
+
+- [ ] **Step 1: Create the curate Dockerfile**
+
+Create `st-scrape/Dockerfile.curate`:
+
+```dockerfile
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Shared scraper module (for any reuse) + the curate package.
+COPY scrape_races.py .
+COPY curate/ ./curate/
+
+# Reads MEET_ID / CURATED_BUCKET / OVERRIDES_TABLE / SNS_TOPIC_ARN from the env.
+ENTRYPOINT ["python", "-m", "curate.run"]
+```
+
+- [ ] **Step 2: Build the image locally to verify it assembles**
+
+Run: `cd st-scrape && docker build -f Dockerfile.curate -t swimtrends-curate:test .`
+Expected: build succeeds; `docker run --rm swimtrends-curate:test` exits with a
+`KeyError: 'MEET_ID'` (env not set) — confirming the entrypoint runs.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add st-scrape/Dockerfile.curate
+git commit -m "build: add curated transform container image"
+```
+
+---
+
+## Task 13: CDK SwimtrendsCuratedStack
+
+**Files:**
+- Create: `swimtrends-app/swimtrends_app/swimtrends_curated_stack.py`
+- Modify: `swimtrends-app/app.py`
+- Test: `swimtrends-app/tests/unit/test_curated_stack.py`
+
+- [ ] **Step 1: Write the failing CDK assertion test**
+
+Create `swimtrends-app/tests/unit/test_curated_stack.py`:
+
+```python
+"""Synth assertions for the curated stack: overrides table, curated task,
+trigger Lambda, Glue database + tables."""
+import aws_cdk as cdk
+from aws_cdk import assertions
+
+from swimtrends_app.swimtrends_curated_stack import SwimtrendsCuratedStack
+
+ENV = cdk.Environment(account="179537025528", region="eu-west-1")
+
+
+def _template():
+    app = cdk.App()
+    stack = SwimtrendsCuratedStack(app, "TestCurated", alert_email=None, env=ENV)
+    return assertions.Template.from_stack(stack)
+
+
+def test_overrides_table_has_composite_key():
+    t = _template()
+    t.has_resource_properties("AWS::DynamoDB::Table", {
+        "TableName": "swimtrends-class-overrides",
+        "KeySchema": [
+            {"AttributeName": "meet_id", "KeyType": "HASH"},
+            {"AttributeName": "race_id", "KeyType": "RANGE"},
+        ],
+    })
+
+
+def test_glue_database_and_five_tables():
+    t = _template()
+    t.resource_count_is("AWS::Glue::Database", 1)
+    t.resource_count_is("AWS::Glue::Table", 5)
+
+
+def test_trigger_lambda_exists():
+    t = _template()
+    t.has_resource_properties("AWS::Lambda::Function", {
+        "Handler": "curate_trigger.lambda_handler",
+    })
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd swimtrends-app && .venv/bin/python -m pytest tests/unit/test_curated_stack.py -v`
+Expected: FAIL — `ModuleNotFoundError: swimtrends_app.swimtrends_curated_stack`.
+
+- [ ] **Step 3: Write the stack**
+
+Create `swimtrends-app/swimtrends_app/swimtrends_curated_stack.py`:
+
+```python
+"""Swimtrends curated zone (Spec 2 of 3).
+
+A class-overrides DynamoDB table, a Fargate task that runs the curated transform,
+an S3-event trigger Lambda (raw results.jsonl -> RunTask), a Glue database with
+one table per curated dataset, and SNS alerts. Reuses the swimtrends-meet-data
+bucket and the ingestion ECS cluster by name."""
+import os
+import sys
+
+from aws_cdk import Duration, Stack
+from aws_cdk import aws_dynamodb as dynamodb
+from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_ecs as ecs
+from aws_cdk import aws_glue as glue
+from aws_cdk import aws_iam as iam
+from aws_cdk import aws_lambda as lambda_
+from aws_cdk import aws_logs as logs
+from aws_cdk import aws_s3 as s3
+from aws_cdk import aws_s3_notifications as s3n
+from aws_cdk import aws_sns as sns
+from aws_cdk import aws_sns_subscriptions as subs
+from constructs import Construct
+
+ST_SCRAPE_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "st-scrape"))
+sys.path.insert(0, ST_SCRAPE_DIR)
+from curate import catalog  # noqa: E402  (import after path insert)
+
+CONTAINER_NAME = "curate"
+BUCKET_NAME = "swimtrends-meet-data"
+CURATED_TABLES = ["dim_meet", "dim_race", "fact_result", "fact_split", "obt_result"]
+
+
+class SwimtrendsCuratedStack(Stack):
+
+    def __init__(self, scope: Construct, construct_id: str,
+                 alert_email: str = None, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        bucket = s3.Bucket.from_bucket_name(self, "DataBucket", BUCKET_NAME)
+
+        overrides = dynamodb.Table(
+            self, "ClassOverrides",
+            table_name="swimtrends-class-overrides",
+            partition_key=dynamodb.Attribute(
+                name="meet_id", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(
+                name="race_id", type=dynamodb.AttributeType.NUMBER),
+            billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
+        )
+
+        topic = sns.Topic(self, "CurateAlertTopic",
+                          display_name="Swimtrends curate alerts")
+        if alert_email:
+            topic.add_subscription(subs.EmailSubscription(alert_email))
+
+        vpc = ec2.Vpc.from_lookup(self, "DefaultVpc", is_default=True)
+        sg = ec2.SecurityGroup(self, "CurateTaskSG", vpc=vpc,
+                               allow_all_outbound=True,
+                               description="Egress-only SG for the curate task")
+        cluster = ecs.Cluster.from_cluster_attributes(
+            self, "Cluster", cluster_name="swimtrends-ingestion",
+            vpc=vpc, security_groups=[])
+
+        task_def = ecs.FargateTaskDefinition(
+            self, "CurateTaskDef", cpu=512, memory_limit_mib=1024)
+        task_def.add_container(
+            CONTAINER_NAME,
+            image=ecs.ContainerImage.from_asset(
+                ST_SCRAPE_DIR, file="Dockerfile.curate"),
+            logging=ecs.LogDriver.aws_logs(
+                stream_prefix="curate",
+                log_retention=logs.RetentionDays.ONE_MONTH),
+            environment={
+                "CURATED_BUCKET": BUCKET_NAME,
+                "OVERRIDES_TABLE": overrides.table_name,
+                "SNS_TOPIC_ARN": topic.topic_arn,
+            },
+        )
+        bucket.grant_read(task_def.task_role, objects_key_pattern="raw/*")
+        bucket.grant_read(task_def.task_role, objects_key_pattern="reference/*")
+        bucket.grant_put(task_def.task_role, objects_key_pattern="curated/*")
+        overrides.grant_read_data(task_def.task_role)
+        topic.grant_publish(task_def.task_role)
+
+        # --- S3-event trigger Lambda: raw results.jsonl lands -> RunTask ---
+        trigger_fn = lambda_.Function(
+            self, "CurateTrigger",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            handler="curate_trigger.lambda_handler",
+            timeout=Duration.minutes(1),
+            memory_size=256,
+            code=lambda_.Code.from_asset(
+                os.path.join(os.path.dirname(__file__), "..", "lambda_curate_trigger")),
+            environment={
+                "ECS_CLUSTER": cluster.cluster_arn,
+                "TASK_DEFINITION": task_def.task_definition_arn,
+                "CONTAINER_NAME": CONTAINER_NAME,
+                "SUBNET_IDS": ",".join(s.subnet_id for s in vpc.public_subnets),
+                "SECURITY_GROUP_ID": sg.security_group_id,
+            },
+        )
+        trigger_fn.add_to_role_policy(iam.PolicyStatement(
+            actions=["ecs:RunTask"], resources=[task_def.task_definition_arn]))
+        trigger_fn.add_to_role_policy(iam.PolicyStatement(
+            actions=["iam:PassRole"],
+            resources=[task_def.task_role.role_arn,
+                       task_def.obtain_execution_role().role_arn]))
+
+        bucket.add_event_notification(
+            s3.EventType.OBJECT_CREATED,
+            s3n.LambdaDestination(trigger_fn),
+            s3.NotificationKeyFilter(prefix="raw/", suffix="results.jsonl"))
+
+        # --- Glue catalog ---
+        db = glue.CfnDatabase(
+            self, "CuratedDatabase",
+            catalog_id=self.account,
+            database_input=glue.CfnDatabase.DatabaseInputProperty(
+                name="swimtrends_curated"))
+        for name in CURATED_TABLES:
+            location = f"s3://{BUCKET_NAME}/curated/{name}/"
+            ti = catalog.table_input(name, location)
+            tbl = glue.CfnTable(
+                self, f"Table{name}",
+                catalog_id=self.account,
+                database_name="swimtrends_curated",
+                table_input=glue.CfnTable.TableInputProperty(
+                    name=ti["Name"],
+                    table_type=ti["TableType"],
+                    parameters=ti["Parameters"],
+                    partition_keys=[
+                        glue.CfnTable.ColumnProperty(name=c["Name"], type=c["Type"])
+                        for c in ti["PartitionKeys"]],
+                    storage_descriptor=glue.CfnTable.StorageDescriptorProperty(
+                        columns=[glue.CfnTable.ColumnProperty(
+                            name=c["Name"], type=c["Type"])
+                            for c in ti["StorageDescriptor"]["Columns"]],
+                        location=location,
+                        input_format=ti["StorageDescriptor"]["InputFormat"],
+                        output_format=ti["StorageDescriptor"]["OutputFormat"],
+                        serde_info=glue.CfnTable.SerdeInfoProperty(
+                            serialization_library=ti["StorageDescriptor"]
+                            ["SerdeInfo"]["SerializationLibrary"]))))
+            tbl.add_dependency(db)
+```
+
+- [ ] **Step 4: Create the trigger Lambda source**
+
+Create `swimtrends-app/lambda_curate_trigger/curate_trigger.py`:
+
+```python
+"""S3 ObjectCreated(raw/.../results.jsonl) -> RunTask the curate Fargate task
+for that meet. Parses meet_id from the key 'raw/meet=<id>/results.jsonl'."""
+import os
+import re
+
+import boto3
+
+KEY_RE = re.compile(r"raw/meet=([^/]+)/results\.jsonl$")
+
+
+def lambda_handler(event, context):
+    ecs = boto3.client("ecs")
+    launched = []
+    for record in event.get("Records", []):
+        key = record["s3"]["object"]["key"]
+        m = KEY_RE.search(key)
+        if not m:
+            continue
+        meet_id = m.group(1)
+        ecs.run_task(
+            cluster=os.environ["ECS_CLUSTER"],
+            taskDefinition=os.environ["TASK_DEFINITION"],
+            launchType="FARGATE",
+            count=1,
+            networkConfiguration={"awsvpcConfiguration": {
+                "subnets": os.environ["SUBNET_IDS"].split(","),
+                "securityGroups": [os.environ["SECURITY_GROUP_ID"]],
+                "assignPublicIp": "ENABLED",
+            }},
+            overrides={"containerOverrides": [{
+                "name": os.environ["CONTAINER_NAME"],
+                "environment": [{"name": "MEET_ID", "value": meet_id}],
+            }]},
+        )
+        launched.append(meet_id)
+    return {"launched": launched}
+```
+
+- [ ] **Step 5: Wire the stack into app.py**
+
+In `swimtrends-app/app.py`, add the import and instantiation:
+
+```python
+from swimtrends_app.swimtrends_curated_stack import SwimtrendsCuratedStack
+```
+
+and after the `SwimtrendsIngestionStack(...)` block:
+
+```python
+SwimtrendsCuratedStack(
+    app, "SwimtrendsCuratedStack",
+    alert_email=app.node.try_get_context("alert_email"),
+    env=ENV,
+)
+```
+
+- [ ] **Step 6: Run the CDK test to verify it passes**
+
+Run: `cd swimtrends-app && .venv/bin/python -m pytest tests/unit/test_curated_stack.py -v`
+Expected: PASS (3 tests). The `glue` import requires `aws-cdk-lib` (already pinned).
+
+- [ ] **Step 7: Synthesize to validate the whole app**
+
+Run:
+```bash
+cd swimtrends-app
+export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use 22
+export AWS_PROFILE=swimtrends AWS_DEFAULT_REGION=eu-west-1 AWS_REGION=eu-west-1
+cdk synth SwimtrendsCuratedStack --app ".venv/bin/python3 app.py" -c alert_email=mortench.privat@gmail.com >/dev/null
+```
+Expected: synth succeeds (no exceptions), emits CloudFormation.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add swimtrends-app/swimtrends_app/swimtrends_curated_stack.py \
+        swimtrends-app/lambda_curate_trigger/curate_trigger.py \
+        swimtrends-app/app.py \
+        swimtrends-app/tests/unit/test_curated_stack.py
+git commit -m "feat: add SwimtrendsCuratedStack (overrides table, curate task, S3 trigger, Glue catalog)"
+```
+
+---
+
+## Task 14: Deploy, seed base times, backfill curate
+
+**Files:** none (operational).
+
+- [ ] **Step 1: Generate and upload the base-times reference**
+
+Run:
+```bash
+cd st-scrape
+.venv/bin/python gen_base_times.py    # writes db/point_base_times.jsonl
+AWS_PROFILE=swimtrends AWS_DEFAULT_REGION=eu-west-1 \
+  aws s3 cp db/point_base_times.jsonl s3://swimtrends-meet-data/reference/point_base_times.jsonl
+```
+Expected: validation passes; object uploaded.
+
+- [ ] **Step 2: Deploy the curated stack**
+
+Run:
+```bash
+cd swimtrends-app
+export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use 22
+export AWS_PROFILE=swimtrends AWS_DEFAULT_REGION=eu-west-1 AWS_REGION=eu-west-1
+cdk deploy SwimtrendsCuratedStack \
+  --app ".venv/bin/python3 app.py" -c alert_email=mortench.privat@gmail.com \
+  --require-approval never --ci
+```
+Expected: stack deploys (Docker must be running for the image asset).
+**Note:** the S3 event notification mutates the shared bucket's config — confirm
+no Spec 1 notification conflict (Spec 1 added none, so this is additive).
+
+- [ ] **Step 3: Backfill — curate all already-scraped meets**
+
+For each meet already in the raw zone, trigger the curate task. Quickest path is
+to re-put the trigger or invoke the curator directly. Using a one-off RunTask per
+meet (replace `<meet_id>`):
+```bash
+AWS_PROFILE=swimtrends AWS_DEFAULT_REGION=eu-west-1 \
+  aws ecs run-task --cluster swimtrends-ingestion \
+  --task-definition <CurateTaskDef-arn> --launch-type FARGATE \
+  --network-configuration '{"awsvpcConfiguration":{"subnets":[...],"securityGroups":[...],"assignPublicIp":"ENABLED"}}' \
+  --overrides '{"containerOverrides":[{"name":"curate","environment":[{"name":"MEET_ID","value":"<meet_id>"}]}]}'
+```
+Expected: each task writes `curated/<table>/season=.../course=.../meet=<id>.parquet`.
+
+- [ ] **Step 4: Verify curated output and points**
+
+Run:
+```bash
+AWS_PROFILE=swimtrends AWS_DEFAULT_REGION=eu-west-1 \
+  aws s3 ls s3://swimtrends-meet-data/curated/ --recursive | head
+```
+Expected: Parquet files under all five table prefixes. Spot-check one
+`obt_result` file (download + `pq.read_table`) and confirm `points` populated for
+open results and `null` for para.
+
+- [ ] **Step 5: Verify the Glue catalog resolves the partitions**
+
+Run a partition repair / load so Glue sees the existing data (Athena, Spec 3, will
+query it):
+```bash
+AWS_PROFILE=swimtrends AWS_DEFAULT_REGION=eu-west-1 \
+  aws glue get-tables --database-name swimtrends_curated \
+  --query 'TableList[].Name'
+```
+Expected: the five table names. (Partition discovery — crawler vs `MSCK`/Athena
+`ALTER TABLE ADD PARTITION` — is finalized in Spec 3 when the query engine lands.)
+
+- [ ] **Step 6: Final commit (docs/status, if any operational notes were added)**
+
+```bash
+git add -A
+git commit -m "chore: curated zone deployed and backfilled" || echo "nothing to commit"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** transform (T5), points (T2), base times (T8/T14), authoritative class + overrides (T3/T7/T10), splits flattening + `result_id` (T4), fact/dim + OBT (T4/T5/T6), Glue catalog (T11/T13), schema contract (the "Curated schemas" section + `parquet.SCHEMAS`), incremental trigger (T13 S3 event) + full rebuild (T10 `curate --all`, T14 backfill), CDK stack reusing bucket/cluster/SNS (T13), Fargate-Python engine (T9/T12). All Spec 2 in-scope items map to a task.
+- **`result_id` correctness:** keyed by race-local ordinal, not `Rank`, because DQs share `Rank=-1` (verified against real raw data). Pinned in T4 test `test_result_id_uses_ordinal_not_rank_so_dqs_dont_collide`.
+- **Naming consistency:** `score_result`, `authoritative_class`, `transform_meet`, `write_parquet_bytes`, `object_key`, `table_input`, `get_for_meet`, `set_override`, `run_curate_task` are used identically across tasks.
+- **Open items deferred to plan-execution/Spec 3 (not blockers):** Glue partition discovery mechanism (crawler vs Athena DDL) is settled in Spec 3; `curate --all` server-side fan-out (T10 sends `{"all": true}`) needs the curator Lambda/handler to enumerate meets — for the backfill, T14 Step 3 drives RunTask per meet directly, so the `--all` server path can be implemented when the query layer needs it.
+```

--- a/docs/superpowers/specs/2026-06-04-curated-zone-design.md
+++ b/docs/superpowers/specs/2026-06-04-curated-zone-design.md
@@ -1,0 +1,295 @@
+# Swimtrends Curated Zone — Design Spec
+
+- **Date:** 2026-06-04
+- **Status:** Approved (design); pending implementation plan
+- **Spec:** 2 of 3 (Curated data lake)
+- **Depends on:** Spec 1 (Ingestion platform — raw zone live)
+
+## Context & goal
+
+Spec 1 lands faithful, scraper-native JSONL in the raw zone — three entities at
+their natural cardinality (`meet_info`, `races`, `results`), splits nested inside
+results, **no points**, and `class` as a best-effort scraper guess. Everything
+derived or destructive was deliberately deferred to here.
+
+Spec 2 turns that raw zone into a **curated, query-optimized data lake**:
+partitioned Parquet, World Aquatics points, a flattened lap-level splits fact,
+**authoritative** para classification, and a Glue Data Catalog so Spec 3
+(Athena in the cloud + Dockerized DuckDB locally) can query it without bespoke
+parsing.
+
+The split Spec 1 drew holds: **raw = faithful source mirror; curated = derived,
+denormalized, analytics-shaped.** All derived logic (points, class authority,
+surrogate keys, splits explosion) lives in this spec.
+
+### Platform decomposition (this spec is #2)
+
+1. **Ingestion platform** *(Spec 1, live)* — Fargate scraper, meet registry +
+   dispatcher, raw JSONL → S3.
+2. **Curated data lake** *(this spec)* — raw → partitioned Parquet + points +
+   authoritative class + flattened splits, Glue catalog, schema contract.
+3. **Analytics access** *(later)* — Athena (cloud) + Dockerized DuckDB (local)
+   over the curated Parquet.
+
+All three share the `swimtrends-meet-data` bucket and the raw layout from Spec 1.
+
+### Live code this spec absorbs
+
+The points/base-times logic exists today as local scripts and becomes the core
+of the curated transform:
+
+- `st-scrape/calc_points.py` — World Aquatics points (`points`, `points_fixed`).
+- `st-scrape/gen_base_times.py` — builds the base-times table from the source
+  markdown.
+- `st-scrape/wa-points/*.md` — the World Aquatics base-times source documents.
+
+These run locally today (which is why local `db/` files show points but the raw
+zone does not). Spec 2 moves them into the deployed curated transform.
+
+## Scope
+
+### In scope
+- A **curated transform**: raw JSONL → partitioned Parquet (Snappy).
+- **World Aquatics points** on every individual result (`points` season-relative
+  + `points_fixed` cross-era), porting `calc_points.py`.
+- A **base-times reference dataset** (porting `gen_base_times.py` +
+  `wa-points/*.md`) as a managed, versioned input.
+- **Authoritative `class`** (open/para) with per-(meet,race) overrides,
+  superseding the raw heuristic.
+- **Splits flattening** into a lap-level `fact_split` with a stable surrogate
+  key (solving the relay `Swimmer_id = null` non-uniqueness problem).
+- Both a **conformed fact/dim** model and a denormalized **one-big-table** view.
+- A **Glue Data Catalog** database + tables over the curated Parquet.
+- An explicit, **versioned schema contract**.
+- CLI/operational hooks to run the transform and edit reference data.
+
+### Out of scope (Spec 3)
+Athena workgroups/queries, the Dockerized DuckDB local query path,
+dashboards/notebooks, and auto-discovery of meets. (Spec 3 only *reads* the
+catalog and Parquet this spec produces.)
+
+## Architecture
+
+### Components
+
+| Component | Service | Role |
+|-----------|---------|------|
+| Curated transform | ECS Fargate task (Python) | raw JSONL → curated Parquet, points, class, splits |
+| Incremental trigger | S3 event → Lambda → RunTask | transform one meet when its raw lands |
+| Batch trigger | CLI / Lambda | full rebuild over all meets |
+| Base-times reference | S3 (versioned object) | WA base times, edited via CLI |
+| Class overrides | DynamoDB `swimtrends-class-overrides` | per-(meet,race) authoritative class |
+| Curated store | S3 `curated/` prefix | partitioned Parquet (fact/dim + OBT) |
+| Catalog | Glue Data Catalog | `swimtrends_curated` database + tables |
+| Alerts | SNS (reuse Spec 1 topic) | transform success/failure |
+
+### Decision: compute engine — Fargate Python (not Glue/Spark)
+
+The transform runs as a **containerized Python Fargate task** reusing the
+existing, validated `calc_points.py` / `gen_base_times.py` logic and writing
+Parquet via **pyarrow**. Rationale:
+
+- The points and class logic already exist as plain Python; Glue/Spark would
+  reimplement (and re-test) it for no benefit at this data volume (tens of meets,
+  thousands of rows each — comfortably single-node).
+- Consistency with Spec 1 (Fargate, scale-to-zero, same ECR/CDK patterns,
+  same SNS topic).
+- DuckDB/pyarrow in-process handles the joins and Parquet writes trivially; this
+  same container image underpins Spec 3's local DuckDB path later.
+
+A NAT-free public-subnet task (as in Spec 1) is fine: the transform reads/writes
+S3 and DynamoDB only (S3/DynamoDB gateway endpoints or public egress).
+
+### Decision: trigger model — incremental + on-demand full rebuild
+
+Both, because they serve different events:
+
+- **Incremental (default).** Spec 1 writes `raw/meet=<id>/results.jsonl` last;
+  an **S3 `ObjectCreated` event** on that suffix invokes a thin Lambda that
+  `ecs:RunTask`s the transform for that one `meet_id`. Cheap, scale-to-zero,
+  keeps curated fresh within minutes of a scrape.
+- **Full rebuild (on demand).** A CLI command (`swimtrends curate --all`)
+  re-transforms every meet. Required because edits to **base times** or **class
+  overrides** are global inputs that invalidate previously-computed points/class
+  across all meets — incremental-per-meet can't capture that. Also the disaster-
+  recovery / schema-migration path.
+
+Both run the same idempotent transform; re-running a meet overwrites its curated
+partition deterministically.
+
+## Curated data model
+
+Two layers over the same transform output.
+
+### Conformed fact/dim (normalized, mirrors raw cardinality)
+
+- **`dim_meet`** — 1 row/meet: `meet_id`, `meet_name`, `venue`, `course`,
+  `season`, `start_date`, `end_date`, `category[]`.
+- **`dim_race`** — 1 row/race: `race_id`, `meet_id`, `number`, `name`,
+  `distance`, `stroke`, `gender`, `relay_count`,
+  `type` ∈ {`Heats`, `Final`, `Timed final`, `Swim-off`}, **authoritative
+  `class`** ∈ {`open`, `para`}.
+- **`fact_result`** — 1 row/swim: surrogate **`result_id`**, `race_id`,
+  `meet_id`, `Rank`, `Name`, `Swimmer_id` (nullable for relays), `nationality`,
+  `club`, `birth_year`, `completed_time`, `completed_centiseconds`,
+  **`points`**, **`points_fixed`**.
+- **`fact_split`** — 1 row/lap: `result_id` (FK), `race_id`, `distance`,
+  `split_time`, `split_centiseconds`, `cumulative_time`, `cumulative_centiseconds`.
+
+### One Big Table (`obt_result`)
+
+`fact_result` denormalized with all `dim_meet` + `dim_race` attributes inlined —
+the friction-free single-table surface for the core analytics questions ("how
+world-class for its era, by stroke / club / season / class"). Splits are **not**
+inlined (cardinality explosion); they remain in `fact_split`, joinable on
+`result_id`.
+
+### The surrogate key (Spec 1 explicitly deferred this)
+
+Relays carry `Swimmer_id = null`, so `race_id + Swimmer_id` is **not unique** and
+cannot key splits. The transform mints a **deterministic** `result_id` =
+`hash(race_id, Rank)` (stable per meet, idempotent across re-runs) and attaches
+it to both `fact_result` and every child `fact_split` row. Determinism means a
+re-transform of the same raw produces identical keys, so curated overwrites are
+safe and joins are stable.
+
+## Points (porting `calc_points.py`)
+
+- **Formula (World Aquatics):** `points = trunc(1000 * (basetime / swimtime)³)`.
+- **`points`** — scored against the **meet's own season** base times
+  (era-relative: "how world-class for its time"). `null` when that
+  season+course+event has no base time.
+- **`points_fixed`** — scored against a single fixed reference season
+  (`FIXED_REF_SEASON = 2026`): one stationary scale across all eras, the metric
+  for long-term trend analysis. `null` only when the event has no base time in
+  the reference season.
+- Base times keyed `(season, course, gender, relay_count, distance, stroke)`;
+  Danish scraper stroke codes (`Fri/Ryg/Bryst/Fly/IM/HM`) map to WA codes
+  (`FREE/BACK/BREAST/FLY/MEDLEY`) — IM and team medley (HM) both → `MEDLEY`.
+
+### Para exclusion (why points + class are colocated here)
+
+World Aquatics able-bodied base times do not apply to para swims. Any result on
+a race whose **authoritative `class = para`** gets `points = points_fixed =
+null` — it is never scored against able-bodied references. This is the concrete
+reason class authority lives in the same transform as points: the points
+calculation *consumes* the authoritative class.
+
+Authoritative class resolution per race:
+1. If a **class override** exists for `(meet_id, race_id)` → use it.
+2. Else apply the raw heuristic carried from Spec 1: a `Timed final` whose
+   `name` also appears as a `Heats`/`Final` event in the same meet is `para`;
+   plain distance (800/1500 free) and relay timed finals are `open`.
+
+(See the project's para-classification note: the `Direkte finale` + duplicate-
+event signal, validated on meet 9775.)
+
+## Reference data (managed inputs)
+
+Two small, human-curated inputs the transform reads on every run.
+
+### Base times — versioned S3 object
+
+Generated from `wa-points/*.md` via the ported `gen_base_times.py`; each
+transcribed row self-validates (seconds recomputed from the time string must
+match the source). Stored as a **versioned** object
+(`s3://swimtrends-meet-data/reference/point_base_times.jsonl`); bucket versioning
+gives free history. Edited via `swimtrends basetimes build` (regenerate from
+markdown) → upload. A change here is a global input → triggers a full rebuild.
+
+### Class overrides — DynamoDB `swimtrends-class-overrides`
+
+Partition key `meet_id` (S), sort key `race_id` (N), attribute `class`
+(`open`|`para`) + `reason`. For edge cases the heuristic can't catch (e.g. a
+para-only event with no open twin to duplicate). Edited via
+`swimtrends class set <meet_id> <race_id> para --reason "..."`. DynamoDB (not a
+file) because overrides are sparse, point-edited, and keyed — and the transform
+already talks to DynamoDB. A change here triggers a rebuild of the affected meet
+(or `--all`).
+
+## Data contracts
+
+### S3 curated layout
+
+```
+s3://swimtrends-meet-data/
+  raw/                          # Spec 1 (input, untouched)
+    meet=<id>/{meet_info,races,results}.jsonl
+  reference/
+    point_base_times.jsonl      # versioned
+  curated/
+    dim_meet/season=<s>/course=<c>/part-*.parquet
+    dim_race/season=<s>/course=<c>/part-*.parquet
+    fact_result/season=<s>/course=<c>/part-*.parquet
+    fact_split/season=<s>/course=<c>/part-*.parquet
+    obt_result/season=<s>/course=<c>/part-*.parquet
+```
+
+- **Partitioning: `season` then `course`.** Matches how analytics slices time and
+  pool length, and how base times are keyed; keeps Athena scans (Spec 3) cheap.
+- Snappy-compressed Parquet. Re-transforming a meet rewrites only its rows within
+  the affected partitions (overwrite-by-meet within partition).
+- Bucket versioning retains prior curated outputs (audit/rollback), as in raw.
+
+### Glue Data Catalog
+
+A `swimtrends_curated` database with one table per curated dataset above
+(`dim_meet`, `dim_race`, `fact_result`, `fact_split`, `obt_result`), partitioned
+by `season`/`course`. Catalog is created/updated by the transform (or a Glue
+crawler on the curated prefix — TBD at plan time; explicit `CreateTable` from the
+known schema is preferred over crawler guesswork).
+
+### Schema contract (versioned)
+
+The curated schemas (column names, types, nullability, the `result_id`
+derivation, the `type`/`class` enums) are pinned in a versioned contract checked
+into the repo alongside this spec. Spec 3 codes against the contract, not against
+inferred Parquet. Breaking changes bump the contract version and require a full
+rebuild.
+
+## IaC structure (CDK)
+
+- **New `SwimtrendsCuratedStack`**: curated transform Fargate task definition +
+  role, the incremental-trigger Lambda + S3 notification, the
+  `swimtrends-class-overrides` DynamoDB table, the Glue database/tables, and
+  curated-prefix IAM.
+- **Reuse** from Spec 1: the `swimtrends-meet-data` bucket (import by name), the
+  ECS cluster, the SNS alert topic, the ECR patterns.
+- Curated transform image is a sibling entrypoint in the same `st-scrape`
+  container (it already carries `calc_points.py`/`gen_base_times.py`), or a thin
+  second image — decided at plan time.
+
+## Observability & failure handling
+
+- **SNS** (reuse Spec 1 topic) on transform **succeeded** (`meet_id`, row counts
+  per table) and **failed** (`meet_id`, error).
+- Transform is **idempotent** and safe to re-run; failures don't corrupt curated
+  (write to a temp prefix then atomic-move per partition, or overwrite-by-meet).
+- CloudWatch logs + an alarm on transform errors and on the incremental Lambda.
+
+## Cost / scale-to-zero
+
+- Curated transform runs only on a scrape event or an explicit rebuild
+  (per-second Fargate billing, no idle compute).
+- S3 (Parquet + versioned reference), DynamoDB on-demand (sparse overrides), Glue
+  catalog, and SNS are negligible at this volume.
+- Idle cost ≈ S3 storage of raw + curated Parquet.
+
+## Assumptions
+
+- Data volume stays single-node-friendly (tens of meets, low-thousands of rows
+  each) → Python/pyarrow, not Spark.
+- `st-scrape` remains the single source of truth for points/base-times logic,
+  shared by the curated transform.
+- World Aquatics base times are senior/able-bodied only; para results are
+  unscored by design.
+- `result_id = hash(race_id, Rank)` is unique within a race (Rank is unique per
+  race in the source); revisit if a meet ever ties ranks.
+
+## Open questions for plan phase
+
+- Glue table creation: explicit `CreateTable` vs crawler.
+- Single shared `st-scrape` image with multiple entrypoints vs a dedicated
+  curated image.
+- Exact atomicity strategy for partition overwrites (temp-prefix move vs
+  per-meet delete+write).

--- a/st-scrape/Dockerfile.curate
+++ b/st-scrape/Dockerfile.curate
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Shared scraper module (for any reuse) + the curate package.
+COPY scrape_races.py .
+COPY curate/ ./curate/
+
+# Reads MEET_ID / CURATED_BUCKET / OVERRIDES_TABLE / SNS_TOPIC_ARN from the env.
+ENTRYPOINT ["python", "-m", "curate.run"]

--- a/st-scrape/curate/basetimes.py
+++ b/st-scrape/curate/basetimes.py
@@ -1,0 +1,15 @@
+"""Load the WA base-times reference into the lookup the points module uses.
+
+Keyed (season, course, gender, relay_count, distance, stroke) -> seconds."""
+import json
+
+
+def parse(jsonl_text):
+    table = {}
+    for line in jsonl_text.splitlines():
+        if not line.strip():
+            continue
+        r = json.loads(line)
+        table[(r["season"], r["course"], r["gender"], r["relay_count"],
+               r["distance"], r["stroke"])] = r["basetime_in_sec"]
+    return table

--- a/st-scrape/curate/catalog.py
+++ b/st-scrape/curate/catalog.py
@@ -1,0 +1,44 @@
+"""Glue Data Catalog table definitions derived from the Parquet schemas.
+
+season/course are partition keys (encoded in the S3 path), so they are declared
+as PartitionKeys and excluded from the regular column list."""
+import pyarrow as pa
+
+from curate import parquet
+
+PARTITION_COLS = ("season", "course")
+
+_ARROW_TO_GLUE = {pa.string(): "string", pa.int64(): "bigint"}
+
+
+def _glue_type(arrow_type):
+    if pa.types.is_list(arrow_type):
+        inner = _ARROW_TO_GLUE[arrow_type.value_type]
+        return f"array<{inner}>"
+    return _ARROW_TO_GLUE[arrow_type]
+
+
+def table_input(table, location):
+    """Return a Glue CreateTable 'TableInput' dict for one curated table."""
+    schema = parquet.SCHEMAS[table]
+    columns = [{"Name": f.name, "Type": _glue_type(f.type)}
+               for f in schema if f.name not in PARTITION_COLS]
+    return {
+        "Name": table,
+        "TableType": "EXTERNAL_TABLE",
+        "Parameters": {"classification": "parquet", "EXTERNAL": "TRUE"},
+        "PartitionKeys": [
+            {"Name": "season", "Type": "bigint"},
+            {"Name": "course", "Type": "string"},
+        ],
+        "StorageDescriptor": {
+            "Columns": columns,
+            "Location": location,
+            "InputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
+            "OutputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+            "SerdeInfo": {
+                "SerializationLibrary":
+                    "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+            },
+        },
+    }

--- a/st-scrape/curate/classify.py
+++ b/st-scrape/curate/classify.py
@@ -1,0 +1,21 @@
+"""Authoritative open/para class for curated races.
+
+Override-else-heuristic. The heuristic mirrors the raw zone's rule: a 'Timed
+final' whose event name also appears as a Heats/Final in the same meet is a para
+event (an able-bodied direct final has no prelim/final twin)."""
+
+
+def authoritative_class(races, overrides):
+    """races: list of dicts with race_id, name, type. overrides: {race_id: class}.
+    Returns {race_id: 'open'|'para'}."""
+    prelim_final_names = {r["name"] for r in races
+                          if r.get("type") in ("Heats", "Final")}
+    resolved = {}
+    for r in races:
+        rid = r["race_id"]
+        if rid in overrides:
+            resolved[rid] = overrides[rid]
+            continue
+        is_para = r.get("type") == "Timed final" and r.get("name") in prelim_final_names
+        resolved[rid] = "para" if is_para else "open"
+    return resolved

--- a/st-scrape/curate/model.py
+++ b/st-scrape/curate/model.py
@@ -1,0 +1,124 @@
+"""Build curated table rows from raw meet/race/result dicts.
+
+result_id is race-local ordinal (f"{race_id}-{i}"), NOT Rank: disqualified swims
+share Rank=-1 and would collide. Raw file order is deterministic, so ordinals are
+stable across re-runs."""
+from curate import points as points_mod
+
+
+def build_dim_meet(meet):
+    return {
+        "meet_id": str(meet["meet_id"]),
+        "meet_name": meet.get("meet", ""),
+        "venue": meet.get("venue", ""),
+        "course": meet["course"],
+        "season": meet["season"],
+        "meet_date": meet.get("date", ""),
+        "category": list(meet.get("category", [])),
+    }
+
+
+def build_dim_race(races, class_by_id, *, season, course):
+    rows = []
+    for r in races:
+        rows.append({
+            "race_id": r["race_id"],
+            "meet_id": str(r["meet_id"]),
+            "number": r.get("number"),
+            "name": r["name"],
+            "distance": r["distance"],
+            "stroke": r["stroke"],
+            "gender": r["gender"],
+            "relay_count": r["relay_count"],
+            "type": r["type"],
+            "class": class_by_id[r["race_id"]],
+            "season": season,
+            "course": course,
+        })
+    return rows
+
+
+def _result_ids(results):
+    """Assign race-local ordinal ids in raw file order."""
+    counters, ids = {}, []
+    for r in results:
+        rid = r["race_id"]
+        i = counters.get(rid, 0)
+        ids.append(f"{rid}-{i}")
+        counters[rid] = i + 1
+    return ids
+
+
+def build_fact_result(results, races_by_id, class_by_id, base_times, *,
+                      meet_id, season, course):
+    ids = _result_ids(results)
+    rows = []
+    for result_id, r in zip(ids, results):
+        race = races_by_id.get(r["race_id"])
+        cs = r.get("completed_centiseconds")
+        if race is None:
+            p = pf = None
+        else:
+            p, pf = points_mod.score_result(
+                base_times, season, course, race,
+                klass=class_by_id.get(r["race_id"], "open"),
+                completed_centiseconds=cs, rank=r.get("Rank"))
+        rows.append({
+            "result_id": result_id,
+            "race_id": r["race_id"],
+            "meet_id": str(meet_id),
+            "rank": r.get("Rank"),
+            "name": r.get("Name", ""),
+            "swimmer_id": r.get("Swimmer_id"),
+            "nationality": r.get("nationality"),
+            "club": r.get("club"),
+            "birth_year": r.get("birth_year"),
+            "completed_time": r.get("completed_time"),
+            "completed_centiseconds": cs,
+            "points": p,
+            "points_fixed": pf,
+            "season": season,
+            "course": course,
+        })
+    return rows
+
+
+def build_fact_split(results, *, meet_id, season, course):
+    ids = _result_ids(results)
+    rows = []
+    for result_id, r in zip(ids, results):
+        for s in r.get("splits", []):
+            rows.append({
+                "result_id": result_id,
+                "race_id": r["race_id"],
+                "distance": s.get("distance"),
+                "split_time": s.get("split_time"),
+                "split_centiseconds": s.get("split_centiseconds"),
+                "cumulative_time": s.get("cumulative_time"),
+                "cumulative_centiseconds": s.get("cumulative_centiseconds"),
+                "season": season,
+                "course": course,
+            })
+    return rows
+
+
+def build_obt(fact_result_rows, meet, races_by_id, class_by_id):
+    rows = []
+    for fr in fact_result_rows:
+        race = races_by_id.get(fr["race_id"], {})
+        row = dict(fr)
+        row.update({
+            "meet_name": meet.get("meet", ""),
+            "venue": meet.get("venue", ""),
+            "meet_date": meet.get("date", ""),
+            "number": race.get("number"),
+            "race_name": race.get("name"),
+            "distance": race.get("distance"),
+            "stroke": race.get("stroke"),
+            "gender": race.get("gender"),
+            "relay_count": race.get("relay_count"),
+            "type": race.get("type"),
+            "class": class_by_id.get(fr["race_id"], "open"),
+        })
+        rows.append(row)
+    return rows

--- a/st-scrape/curate/overrides.py
+++ b/st-scrape/curate/overrides.py
@@ -1,0 +1,25 @@
+"""DynamoDB access for per-(meet,race) authoritative class overrides.
+
+Partition key meet_id (S), sort key race_id (N). Sparse: only the handful of
+races the heuristic gets wrong."""
+import boto3
+from boto3.dynamodb.conditions import Key
+
+
+class ClassOverrides:
+    def __init__(self, table_name, region=None):
+        self._table = boto3.resource("dynamodb", region_name=region).Table(table_name)
+
+    def set_override(self, meet_id, race_id, klass, reason=""):
+        if klass not in ("open", "para"):
+            raise ValueError(f"class must be 'open' or 'para', got {klass!r}")
+        self._table.put_item(Item={
+            "meet_id": str(meet_id), "race_id": int(race_id),
+            "class": klass, "reason": reason,
+        })
+
+    def get_for_meet(self, meet_id):
+        """Return {race_id(int): class} for one meet."""
+        resp = self._table.query(
+            KeyConditionExpression=Key("meet_id").eq(str(meet_id)))
+        return {int(i["race_id"]): i["class"] for i in resp.get("Items", [])}

--- a/st-scrape/curate/parquet.py
+++ b/st-scrape/curate/parquet.py
@@ -1,0 +1,61 @@
+"""Parquet schemas + writer + S3 object keys for the curated zone.
+
+Explicit pyarrow schemas (not inferred) so an empty meet still writes a
+well-typed file and the Glue catalog stays stable."""
+import io
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+_S = pa.string()
+_I = pa.int64()
+
+SCHEMAS = {
+    "dim_meet": pa.schema([
+        ("meet_id", _S), ("meet_name", _S), ("venue", _S), ("course", _S),
+        ("season", _I), ("meet_date", _S), ("category", pa.list_(_S)),
+    ]),
+    "dim_race": pa.schema([
+        ("race_id", _I), ("meet_id", _S), ("number", _I), ("name", _S),
+        ("distance", _I), ("stroke", _S), ("gender", _S), ("relay_count", _I),
+        ("type", _S), ("class", _S), ("season", _I), ("course", _S),
+    ]),
+    "fact_result": pa.schema([
+        ("result_id", _S), ("race_id", _I), ("meet_id", _S), ("rank", _I),
+        ("name", _S), ("swimmer_id", _S), ("nationality", _S), ("club", _S),
+        ("birth_year", _I), ("completed_time", _S), ("completed_centiseconds", _I),
+        ("points", _I), ("points_fixed", _I), ("season", _I), ("course", _S),
+    ]),
+    "fact_split": pa.schema([
+        ("result_id", _S), ("race_id", _I), ("distance", _I), ("split_time", _S),
+        ("split_centiseconds", _I), ("cumulative_time", _S),
+        ("cumulative_centiseconds", _I), ("season", _I), ("course", _S),
+    ]),
+    "obt_result": pa.schema([
+        ("result_id", _S), ("race_id", _I), ("meet_id", _S), ("rank", _I),
+        ("name", _S), ("swimmer_id", _S), ("nationality", _S), ("club", _S),
+        ("birth_year", _I), ("completed_time", _S), ("completed_centiseconds", _I),
+        ("points", _I), ("points_fixed", _I), ("season", _I), ("course", _S),
+        ("meet_name", _S), ("venue", _S), ("meet_date", _S), ("number", _I),
+        ("race_name", _S), ("distance", _I), ("stroke", _S), ("gender", _S),
+        ("relay_count", _I), ("type", _S), ("class", _S),
+    ]),
+}
+
+
+def object_key(table, *, season, course, meet_id):
+    return (f"curated/{table}/season={season}/course={course}/"
+            f"meet={meet_id}.parquet")
+
+
+def write_parquet_bytes(table, rows):
+    """Serialize rows to Snappy Parquet bytes using the table's fixed schema.
+    Missing keys become nulls; extra keys are ignored."""
+    schema = SCHEMAS[table]
+    columns = {name: [row.get(name) for row in rows] for name in schema.names}
+    arrays = [pa.array(columns[name], type=field.type)
+              for name, field in zip(schema.names, schema)]
+    arrow_table = pa.table(arrays, schema=schema)
+    buf = io.BytesIO()
+    pq.write_table(arrow_table, buf, compression="snappy")
+    return buf.getvalue()

--- a/st-scrape/curate/points.py
+++ b/st-scrape/curate/points.py
@@ -1,0 +1,43 @@
+"""World Aquatics points (pure). Ported from calc_points.py.
+
+points = trunc(1000 * (basetime / swimtime) ** 3).
+Two scores per result:
+  points        - vs the meet's OWN season base times (era-relative).
+  points_fixed  - vs FIXED_REF_SEASON (one stationary cross-era scale).
+"""
+import math
+
+FIXED_REF_SEASON = 2026
+
+# Danish scraper stroke codes -> base-time stroke codes. IM (individual medley)
+# and HM (holdmedley / team medley relay) both map to MEDLEY.
+STROKE_MAP = {"Fri": "FREE", "Ryg": "BACK", "Bryst": "BREAST", "Fly": "FLY",
+              "IM": "MEDLEY", "HM": "MEDLEY"}
+
+
+def calculate_points(basetime_sec, swimtime_sec):
+    """WA points, truncated to an integer."""
+    return math.trunc(1000 * math.pow(basetime_sec / swimtime_sec, 3))
+
+
+def points_for(table, season, course, race, swimtime_sec):
+    """Look up the base time for this race+season and score it, or None."""
+    stroke = STROKE_MAP.get(race.get("stroke"))
+    if stroke is None:
+        return None
+    base = table.get((season, course, race["gender"], race["relay_count"],
+                      race["distance"], stroke))
+    if base is None:
+        return None
+    return calculate_points(base, swimtime_sec)
+
+
+def score_result(table, season, course, race, *, klass,
+                 completed_centiseconds, rank):
+    """Return (points, points_fixed). Para, DQ (rank -1), and missing-time
+    results are never scored."""
+    if klass == "para" or completed_centiseconds is None or rank == -1:
+        return (None, None)
+    t = completed_centiseconds / 100.0
+    return (points_for(table, season, course, race, t),
+            points_for(table, FIXED_REF_SEASON, course, race, t))

--- a/st-scrape/curate/run.py
+++ b/st-scrape/curate/run.py
@@ -1,0 +1,77 @@
+"""Curated transform task entrypoint.
+
+run_curate_task() is pure-ish orchestration with all I/O injected (read_text,
+get_overrides, write_bytes, notify) so it unit-tests without AWS. main() wires
+the real boto3 implementations and is the Fargate container entry."""
+import json
+import os
+
+from curate import basetimes, parquet, transform
+
+RAW_PREFIX = "raw/meet={meet_id}/"
+BASE_TIMES_KEY = "reference/point_base_times.jsonl"
+
+
+def _read_jsonl(read_text, key):
+    return [json.loads(l) for l in read_text(key).splitlines() if l.strip()]
+
+
+def run_curate_task(*, meet_id, read_text, get_overrides, write_bytes, notify):
+    """Transform one meet's raw zone into curated Parquet. Re-raises on failure
+    after notifying, so the container exits non-zero."""
+    try:
+        prefix = RAW_PREFIX.format(meet_id=meet_id)
+        meet = _read_jsonl(read_text, prefix + "meet_info.jsonl")[0]
+        races = _read_jsonl(read_text, prefix + "races.jsonl")
+        results = _read_jsonl(read_text, prefix + "results.jsonl")
+        base_times = basetimes.parse(read_text(BASE_TIMES_KEY))
+        overrides = get_overrides(meet_id)
+
+        tables = transform.transform_meet(meet, races, results, base_times, overrides)
+        season, course = meet["season"], meet["course"]
+        counts = {}
+        for table_name, rows in tables.items():
+            key = parquet.object_key(table_name, season=season, course=course,
+                                     meet_id=meet_id)
+            write_bytes(key, parquet.write_parquet_bytes(table_name, rows))
+            counts[table_name] = len(rows)
+
+        notify("Swimtrends curate SUCCEEDED",
+               f"Meet {meet_id} ({meet.get('meet','')}) curated: {counts}")
+        return counts
+    except Exception as e:
+        notify("Swimtrends curate FAILED", f"Meet {meet_id}: {e}")
+        raise
+
+
+def main():
+    import boto3
+
+    from curate.overrides import ClassOverrides
+
+    meet_id = os.environ["MEET_ID"]
+    bucket = os.environ["CURATED_BUCKET"]
+    topic_arn = os.environ["SNS_TOPIC_ARN"]
+    overrides = ClassOverrides(os.environ["OVERRIDES_TABLE"])
+
+    s3 = boto3.client("s3")
+    sns = boto3.client("sns")
+
+    def read_text(key):
+        return s3.get_object(Bucket=bucket, Key=key)["Body"].read().decode("utf-8")
+
+    def write_bytes(key, data):
+        s3.put_object(Bucket=bucket, Key=key, Body=data)
+
+    run_curate_task(
+        meet_id=meet_id,
+        read_text=read_text,
+        get_overrides=overrides.get_for_meet,
+        write_bytes=write_bytes,
+        notify=lambda subject, msg: sns.publish(
+            TopicArn=topic_arn, Subject=subject[:100], Message=msg),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/st-scrape/curate/run.py
+++ b/st-scrape/curate/run.py
@@ -5,6 +5,7 @@ get_overrides, write_bytes, notify) so it unit-tests without AWS. main() wires
 the real boto3 implementations and is the Fargate container entry."""
 import json
 import os
+import sys
 
 from curate import basetimes, parquet, transform
 
@@ -12,8 +13,17 @@ RAW_PREFIX = "raw/meet={meet_id}/"
 BASE_TIMES_KEY = "reference/point_base_times.jsonl"
 
 
+def _safe_notify(notify, subject, message):
+    """Notifications are auxiliary; never let a notify failure mask the real
+    error on the failure path or a successful write on the success path."""
+    try:
+        notify(subject, message)
+    except Exception as e:  # noqa: BLE001 - best effort
+        print(f"notify failed ({subject!r}): {e}", file=sys.stderr)
+
+
 def _read_jsonl(read_text, key):
-    return [json.loads(l) for l in read_text(key).splitlines() if l.strip()]
+    return [json.loads(line) for line in read_text(key).splitlines() if line.strip()]
 
 
 def run_curate_task(*, meet_id, read_text, get_overrides, write_bytes, notify):
@@ -21,7 +31,10 @@ def run_curate_task(*, meet_id, read_text, get_overrides, write_bytes, notify):
     after notifying, so the container exits non-zero."""
     try:
         prefix = RAW_PREFIX.format(meet_id=meet_id)
-        meet = _read_jsonl(read_text, prefix + "meet_info.jsonl")[0]
+        meet_rows = _read_jsonl(read_text, prefix + "meet_info.jsonl")
+        if not meet_rows:
+            raise ValueError(f"meet_info.jsonl for meet {meet_id} is empty")
+        meet = meet_rows[0]
         races = _read_jsonl(read_text, prefix + "races.jsonl")
         results = _read_jsonl(read_text, prefix + "results.jsonl")
         base_times = basetimes.parse(read_text(BASE_TIMES_KEY))
@@ -36,11 +49,11 @@ def run_curate_task(*, meet_id, read_text, get_overrides, write_bytes, notify):
             write_bytes(key, parquet.write_parquet_bytes(table_name, rows))
             counts[table_name] = len(rows)
 
-        notify("Swimtrends curate SUCCEEDED",
-               f"Meet {meet_id} ({meet.get('meet','')}) curated: {counts}")
+        _safe_notify(notify, "Swimtrends curate SUCCEEDED",
+                     f"Meet {meet_id} ({meet.get('meet','')}) curated: {counts}")
         return counts
     except Exception as e:
-        notify("Swimtrends curate FAILED", f"Meet {meet_id}: {e}")
+        _safe_notify(notify, "Swimtrends curate FAILED", f"Meet {meet_id}: {e}")
         raise
 
 

--- a/st-scrape/curate/transform.py
+++ b/st-scrape/curate/transform.py
@@ -1,0 +1,23 @@
+"""Pure curated transform: parsed raw dicts -> {table_name: [row dicts]}."""
+from curate import classify, model
+
+
+def transform_meet(meet, races, results, base_times, overrides):
+    """meet: dict. races/results: lists of dicts. base_times: lookup table.
+    overrides: {race_id: 'open'|'para'}. Returns the five curated tables."""
+    season, course = meet["season"], meet["course"]
+    class_by_id = classify.authoritative_class(races, overrides)
+    races_by_id = {r["race_id"]: r for r in races}
+
+    fact_result = model.build_fact_result(
+        results, races_by_id, class_by_id, base_times,
+        meet_id=meet["meet_id"], season=season, course=course)
+
+    return {
+        "dim_meet": [model.build_dim_meet(meet)],
+        "dim_race": model.build_dim_race(races, class_by_id, season=season, course=course),
+        "fact_result": fact_result,
+        "fact_split": model.build_fact_split(
+            results, meet_id=meet["meet_id"], season=season, course=course),
+        "obt_result": model.build_obt(fact_result, meet, races_by_id, class_by_id),
+    }

--- a/st-scrape/ingestion/cli.py
+++ b/st-scrape/ingestion/cli.py
@@ -40,11 +40,25 @@ def build_parser():
                       help="Target every scheduled meet (use with --force to backfill).")
     disp.add_argument("--force", action="store_true",
                       help="Bypass the grace/completeness gates.")
+
+    cur = sub.add_parser("curate", help="Run the curated transform.")
+    cur.add_argument("meet_id", nargs="?", default=None)
+    cur.add_argument("--all", action="store_true",
+                     help="Curate every meet (full rebuild).")
+
+    cls = sub.add_parser("class", help="Manage authoritative class overrides.")
+    cls_sub = cls.add_subparsers(dest="class_command", required=True)
+    cls_set = cls_sub.add_parser("set", help="Set an override for one race.")
+    cls_set.add_argument("meet_id")
+    cls_set.add_argument("race_id", type=int)
+    cls_set.add_argument("klass", choices=["open", "para"])
+    cls_set.add_argument("--reason", default="")
+
     return parser
 
 
-def run(argv, *, registry, invoke):
-    """Execute one CLI command. registry/invoke are injected for testing."""
+def run(argv, *, registry, invoke, curate=None, overrides=None):
+    """Execute one CLI command. registry/invoke/curate/overrides injected."""
     args = build_parser().parse_args(argv)
 
     if args.command == "register":
@@ -87,6 +101,24 @@ def run(argv, *, registry, invoke):
             print(f"Dispatcher result: {result}")
         return
 
+    if args.command == "curate":
+        if args.all and args.meet_id:
+            raise SystemExit("Pass a meet_id OR --all, not both.")
+        if not args.all and not args.meet_id:
+            raise SystemExit("curate needs a meet_id or --all.")
+        payload = {"all": True} if args.all else {"meet_ids": [args.meet_id]}
+        curate(payload)
+        print(f"Curate invoked with payload: {json.dumps(payload)}")
+        return
+
+    if args.command == "class":
+        if args.class_command == "set":
+            overrides.set_override(args.meet_id, args.race_id, args.klass,
+                                   reason=args.reason)
+            print(f"Override set: meet {args.meet_id} race {args.race_id} "
+                  f"-> {args.klass}")
+        return
+
 
 def main():
     import boto3
@@ -106,7 +138,22 @@ def main():
         body = resp["Payload"].read().decode("utf-8")
         return json.loads(body) if body else None
 
-    run(sys.argv[1:], registry=registry, invoke=invoke)
+    from curate.overrides import ClassOverrides
+
+    overrides = ClassOverrides(os.environ["OVERRIDES_TABLE"]) \
+        if os.environ.get("OVERRIDES_TABLE") else None
+    curator_fn = os.environ.get("CURATOR_FUNCTION")
+
+    def curate(payload):
+        if curator_fn is None:
+            raise SystemExit("CURATOR_FUNCTION not set.")
+        resp = lambda_client.invoke(
+            FunctionName=curator_fn, InvocationType="Event",
+            Payload=json.dumps(payload).encode("utf-8"))
+        return resp["StatusCode"]
+
+    run(sys.argv[1:], registry=registry, invoke=invoke,
+        curate=curate, overrides=overrides)
 
 
 if __name__ == "__main__":

--- a/st-scrape/ingestion/dispatcher.py
+++ b/st-scrape/ingestion/dispatcher.py
@@ -5,11 +5,17 @@ run_cycle() is pure-ish orchestration with all side effects injected
 wires the real boto3 + scraper implementations and is the EventBridge/CLI entry.
 """
 import os
+from datetime import datetime, timedelta, timezone
 
 from ingestion import completion
 from ingestion.registry import MeetRegistry
 
 DEFAULT_MAX_ATTEMPTS = 3
+
+# A scrape task that has held its 'scraping' claim longer than this is presumed
+# orphaned (its container died before recording a terminal status). Generous
+# enough to never reap a genuinely in-progress, politely-throttled scrape.
+DEFAULT_REAP_TTL_HOURS = 6
 
 
 def run_cycle(registry, *, now, run_task, has_results, notify,
@@ -71,6 +77,84 @@ def run_cycle(registry, *, now, run_task, has_results, notify,
     return dispatched
 
 
+def _claim_is_stale(meet, now, ttl_hours):
+    """True if this 'scraping' meet has held its claim past the TTL. A row with
+    no claimed_at predates the field (legacy claim) and is treated as stale."""
+    claimed_at = meet.get("claimed_at")
+    if not claimed_at:
+        return True
+    claimed = datetime.strptime(claimed_at, "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc)
+    return now - claimed >= timedelta(hours=ttl_hours)
+
+
+def reconcile_raw(read_text, meet_id):
+    """Reconstruct scrape counts from the raw zone for an orphaned meet.
+
+    read_text(key) returns the object body as str, or None if it is absent.
+    Returns {meet_name, result_count, race_count} when all three raw files are
+    present and meet_info is non-empty (a completed scrape with a lost terminal
+    write), else None (incomplete — re-scrape instead).
+    """
+    import json
+
+    prefix = f"raw/meet={meet_id}/"
+    info = read_text(prefix + "meet_info.jsonl")
+    races = read_text(prefix + "races.jsonl")
+    results = read_text(prefix + "results.jsonl")
+    if info is None or races is None or results is None:
+        return None
+
+    info_lines = [ln for ln in info.splitlines() if ln.strip()]
+    if not info_lines:
+        return None
+
+    return {
+        "meet_name": json.loads(info_lines[0]).get("meet", ""),
+        "result_count": sum(1 for ln in results.splitlines() if ln.strip()),
+        "race_count": sum(1 for ln in races.splitlines() if ln.strip()),
+    }
+
+
+def run_reaper(registry, *, now, reconcile, notify,
+               ttl_hours=DEFAULT_REAP_TTL_HOURS):
+    """Resolve meets orphaned in 'scraping' (container died before the terminal
+    mark_scraped/mark_failed write). For each stale claim, reconcile from the
+    raw zone if the data is all there (a lost terminal write — not a re-scrape),
+    otherwise reset to 'failed' so the dispatcher retries it.
+
+    reconcile(meet_id) returns {meet_name, result_count, race_count} when the
+    raw files are all present, else None.
+
+    Returns a list of (meet_id, action) where action is reconciled|reclaimed.
+    """
+    resolved = []
+    for meet in registry.scraping_meets():
+        meet_id = meet["meet_id"]
+        if not _claim_is_stale(meet, now, ttl_hours):
+            continue
+
+        counts = reconcile(meet_id)
+        if counts is not None:
+            registry.mark_scraped(meet_id, counts["meet_name"],
+                                  counts["result_count"], counts["race_count"])
+            notify("Swimtrends orphaned scrape reconciled",
+                   f"Meet {meet_id} was stuck in 'scraping' but its raw data is "
+                   f"complete ({counts['result_count']} results / "
+                   f"{counts['race_count']} races); reconciled to scraped.")
+            resolved.append((meet_id, "reconciled"))
+        else:
+            registry.mark_failed(
+                meet_id, "Reaped: orphaned in 'scraping' past TTL with no "
+                "complete raw data in S3.")
+            notify("Swimtrends orphaned scrape reclaimed",
+                   f"Meet {meet_id} was stuck in 'scraping' with no usable raw "
+                   f"data; reset to failed for retry.")
+            resolved.append((meet_id, "reclaimed"))
+
+    return resolved
+
+
 # --------------------------------------------------------------------------
 # Lambda wiring (real AWS implementations)
 # --------------------------------------------------------------------------
@@ -90,7 +174,9 @@ def lambda_handler(event, context):
 
     ecs = boto3.client("ecs")
     sns = boto3.client("sns")
+    s3 = boto3.client("s3")
     topic_arn = os.environ["SNS_TOPIC_ARN"]
+    raw_bucket = os.environ["RAW_BUCKET"]
 
     def run_task(meet_id, category):
         ecs.run_task(
@@ -119,15 +205,36 @@ def lambda_handler(event, context):
     def notify(subject, message):
         sns.publish(TopicArn=topic_arn, Subject=subject[:100], Message=message)
 
+    def read_text(key):
+        try:
+            return s3.get_object(Bucket=raw_bucket, Key=key)["Body"].read().decode("utf-8")
+        except s3.exceptions.NoSuchKey:
+            return None
+
     event = event or {}
+    meet_ids = event.get("meet_ids")
+
+    # On a full cycle (the hourly EventBridge trigger, not a targeted CLI
+    # invoke) first reap meets orphaned in 'scraping' by a dead container.
+    reaped = []
+    if meet_ids is None:
+        reaped = run_reaper(
+            registry,
+            now=now,
+            reconcile=lambda mid: reconcile_raw(read_text, mid),
+            notify=notify,
+            ttl_hours=int(os.environ.get("REAP_TTL_HOURS", DEFAULT_REAP_TTL_HOURS)),
+        )
+
     dispatched = run_cycle(
         registry,
         now=now,
         run_task=run_task,
         has_results=scrape_races.meet_has_results,
         notify=notify,
-        meet_ids=event.get("meet_ids"),
+        meet_ids=meet_ids,
         force=bool(event.get("force", False)),
         max_attempts=int(os.environ.get("MAX_ATTEMPTS", DEFAULT_MAX_ATTEMPTS)),
     )
-    return {"dispatched": dispatched, "count": len(dispatched)}
+    return {"dispatched": dispatched, "count": len(dispatched),
+            "reaped": reaped}

--- a/st-scrape/ingestion/registry.py
+++ b/st-scrape/ingestion/registry.py
@@ -34,9 +34,8 @@ class MeetRegistry:
     def get(self, meet_id):
         return self._table.get_item(Key={"meet_id": meet_id}).get("Item")
 
-    def scheduled_meets(self):
-        """All meets eligible for (re)scraping: status in scheduled|failed."""
-        items, kwargs = [], {"FilterExpression": Attr("status").is_in(list(PICKABLE))}
+    def _scan(self, condition):
+        items, kwargs = [], {"FilterExpression": condition}
         while True:
             resp = self._table.scan(**kwargs)
             items.extend(resp.get("Items", []))
@@ -44,16 +43,32 @@ class MeetRegistry:
                 return items
             kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
 
-    def claim(self, meet_id):
-        """Atomically move scheduled|failed -> scraping and bump attempts.
+    def scheduled_meets(self):
+        """All meets eligible for (re)scraping: status in scheduled|failed."""
+        return self._scan(Attr("status").is_in(list(PICKABLE)))
+
+    def scraping_meets(self):
+        """All meets currently claimed and in flight (status == scraping).
+
+        The reaper inspects these for orphans whose container died before
+        recording a terminal status."""
+        return self._scan(Attr("status").eq("scraping"))
+
+    def claim(self, meet_id, when=None):
+        """Atomically move scheduled|failed -> scraping, bump attempts, and
+        stamp claimed_at so the reaper can detect a stale (orphaned) claim.
         Returns True if this caller won the claim, False if already taken."""
         try:
             self._table.update_item(
                 Key={"meet_id": meet_id},
-                UpdateExpression="SET #s = :scraping ADD attempts :one",
+                UpdateExpression="SET #s = :scraping, claimed_at = :t ADD attempts :one",
                 ConditionExpression=Attr("status").is_in(list(PICKABLE)),
                 ExpressionAttributeNames={"#s": "status"},
-                ExpressionAttributeValues={":scraping": "scraping", ":one": 1},
+                ExpressionAttributeValues={
+                    ":scraping": "scraping",
+                    ":one": 1,
+                    ":t": _now_iso() if when is None else when,
+                },
             )
             return True
         except self._table.meta.client.exceptions.ConditionalCheckFailedException:
@@ -64,7 +79,7 @@ class MeetRegistry:
             Key={"meet_id": meet_id},
             UpdateExpression=(
                 "SET #s = :scraped, meet_name = :n, result_count = :rc, "
-                "race_count = :rac, last_scraped_at = :t REMOVE last_error"
+                "race_count = :rac, last_scraped_at = :t REMOVE last_error, claimed_at"
             ),
             ConditionExpression=Attr("meet_id").exists(),
             ExpressionAttributeNames={"#s": "status"},
@@ -80,7 +95,10 @@ class MeetRegistry:
     def mark_failed(self, meet_id, error, when=None):
         self._table.update_item(
             Key={"meet_id": meet_id},
-            UpdateExpression="SET #s = :failed, last_error = :e, last_scraped_at = :t",
+            UpdateExpression=(
+                "SET #s = :failed, last_error = :e, last_scraped_at = :t "
+                "REMOVE claimed_at"
+            ),
             ConditionExpression=Attr("meet_id").exists(),
             ExpressionAttributeNames={"#s": "status"},
             ExpressionAttributeValues={

--- a/st-scrape/requirements.txt
+++ b/st-scrape/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.31
 beautifulsoup4>=4.12
 boto3>=1.34
 tzdata>=2024.1
+pyarrow>=15.0

--- a/st-scrape/tests/test_cli_curate.py
+++ b/st-scrape/tests/test_cli_curate.py
@@ -1,0 +1,42 @@
+"""CLI curate/class subcommands route to the right injected side effects."""
+from ingestion import cli
+
+
+class FakeRegistry:
+    def __init__(self, ids):
+        self._ids = ids
+
+    def scheduled_meets(self):  # unused here but matches interface
+        return []
+
+    def all_meet_ids(self):
+        return self._ids
+
+
+class FakeOverrides:
+    def __init__(self):
+        self.calls = []
+
+    def set_override(self, meet_id, race_id, klass, reason=""):
+        self.calls.append((meet_id, race_id, klass, reason))
+
+
+def test_curate_single_meet_invokes_curator():
+    invoked = []
+    cli.run(["curate", "8609"], registry=None, invoke=None,
+            curate=lambda payload: invoked.append(payload), overrides=None)
+    assert invoked == [{"meet_ids": ["8609"]}]
+
+
+def test_curate_all_invokes_with_all_flag():
+    invoked = []
+    cli.run(["curate", "--all"], registry=None, invoke=None,
+            curate=lambda payload: invoked.append(payload), overrides=None)
+    assert invoked == [{"all": True}]
+
+
+def test_class_set_writes_override():
+    ov = FakeOverrides()
+    cli.run(["class", "set", "8609", "213", "para", "--reason", "para-only"],
+            registry=None, invoke=None, curate=None, overrides=ov)
+    assert ov.calls == [("8609", 213, "para", "para-only")]

--- a/st-scrape/tests/test_cli_curate.py
+++ b/st-scrape/tests/test_cli_curate.py
@@ -2,17 +2,6 @@
 from ingestion import cli
 
 
-class FakeRegistry:
-    def __init__(self, ids):
-        self._ids = ids
-
-    def scheduled_meets(self):  # unused here but matches interface
-        return []
-
-    def all_meet_ids(self):
-        return self._ids
-
-
 class FakeOverrides:
     def __init__(self):
         self.calls = []

--- a/st-scrape/tests/test_curate_basetimes.py
+++ b/st-scrape/tests/test_curate_basetimes.py
@@ -1,0 +1,16 @@
+"""Base-times loader parses JSONL into the (season,course,gender,relay,dist,stroke)
+-> seconds lookup the points module expects."""
+from curate import basetimes
+
+JSONL = (
+    '{"season": 2022, "course": "LCM", "gender": "F", "relay_count": 1, '
+    '"distance": 100, "stroke": "FREE", "basetime": "51.71", "basetime_in_sec": 51.71}\n'
+    '{"season": 2026, "course": "LCM", "gender": "F", "relay_count": 1, '
+    '"distance": 100, "stroke": "FREE", "basetime": "50.00", "basetime_in_sec": 50.0}\n'
+)
+
+
+def test_parse_jsonl_to_lookup():
+    table = basetimes.parse(JSONL)
+    assert table[(2022, "LCM", "F", 1, 100, "FREE")] == 51.71
+    assert table[(2026, "LCM", "F", 1, 100, "FREE")] == 50.0

--- a/st-scrape/tests/test_curate_catalog.py
+++ b/st-scrape/tests/test_curate_catalog.py
@@ -1,0 +1,20 @@
+"""Glue table input is derived from the same schema, partitioned by season/course."""
+from curate import catalog
+
+
+def test_table_input_has_partition_keys_and_columns():
+    ti = catalog.table_input("fact_result", "s3://bucket/curated/fact_result/")
+    assert ti["Name"] == "fact_result"
+    part_keys = [c["Name"] for c in ti["PartitionKeys"]]
+    assert part_keys == ["season", "course"]
+    col_names = [c["Name"] for c in ti["StorageDescriptor"]["Columns"]]
+    # Partition columns must NOT also appear in Columns (Glue rejects overlap).
+    assert "season" not in col_names and "course" not in col_names
+    assert "result_id" in col_names and "points" in col_names
+    assert ti["StorageDescriptor"]["Location"] == "s3://bucket/curated/fact_result/"
+
+
+def test_all_five_tables_supported():
+    for name in ["dim_meet", "dim_race", "fact_result", "fact_split", "obt_result"]:
+        ti = catalog.table_input(name, f"s3://bucket/curated/{name}/")
+        assert ti["Name"] == name

--- a/st-scrape/tests/test_curate_classify.py
+++ b/st-scrape/tests/test_curate_classify.py
@@ -1,0 +1,34 @@
+"""Authoritative class = per-(meet,race) override if present, else the raw
+Timed-final-duplicating-a-prelim/final heuristic."""
+from curate import classify
+
+
+def _race(race_id, name, rtype):
+    return {"race_id": race_id, "name": name, "type": rtype}
+
+
+def test_heuristic_marks_timed_final_duplicate_as_para():
+    races = [
+        _race(1, "100 Fri - Damer", "Heats"),
+        _race(2, "100 Fri - Damer", "Final"),
+        _race(3, "100 Fri - Damer", "Timed final"),  # para: duplicates a prelim/final
+        _race(4, "800 Fri - Damer", "Timed final"),   # open: no prelim/final twin
+    ]
+    resolved = classify.authoritative_class(races, overrides={})
+    assert resolved == {1: "open", 2: "open", 3: "para", 4: "open"}
+
+
+def test_override_wins_over_heuristic():
+    races = [_race(9, "50 Fri - Herrer", "Timed final")]  # heuristic -> open
+    resolved = classify.authoritative_class(races, overrides={9: "para"})
+    assert resolved == {9: "para"}
+
+
+def test_override_can_force_open():
+    races = [
+        _race(1, "100 Fri - Damer", "Heats"),
+        _race(2, "100 Fri - Damer", "Final"),
+        _race(3, "100 Fri - Damer", "Timed final"),  # heuristic -> para
+    ]
+    resolved = classify.authoritative_class(races, overrides={3: "open"})
+    assert resolved[3] == "open"

--- a/st-scrape/tests/test_curate_model.py
+++ b/st-scrape/tests/test_curate_model.py
@@ -1,0 +1,73 @@
+"""Row builders: dim_meet, dim_race, fact_result (+ result_id, points),
+fact_split, obt_result."""
+from curate import model
+
+MEET = {"meet_id": 8609, "meet": "DM Langbane 2021", "venue": "Aarhus",
+        "course": "LCM", "season": 2021, "date": "08-07-2021",
+        "category": ["DM-L", "DMJ-L"]}
+
+RACES = [
+    {"meet_id": 8609, "race_id": 1, "number": 1, "name": "100 Fri - Damer",
+     "distance": 100, "stroke": "Fri", "gender": "F", "relay_count": 1,
+     "type": "Final", "class": "open"},
+]
+
+RESULTS = [
+    {"race_id": 1, "Rank": 1, "Name": "A B", "Swimmer_id": "7", "nationality": "DK",
+     "club": "C", "birth_year": 2001, "completed_time": "1:00.00",
+     "completed_centiseconds": 6000,
+     "splits": [{"distance": 50, "split_time": "29.00", "split_centiseconds": 2900,
+                 "cumulative_time": "29.00", "cumulative_centiseconds": 2900}]},
+    {"race_id": 1, "Rank": -1, "Name": "DQ One", "Swimmer_id": "8", "nationality": "DK",
+     "club": "C", "birth_year": 2002, "completed_time": "DQ",
+     "completed_centiseconds": None, "splits": []},
+    {"race_id": 1, "Rank": -1, "Name": "DQ Two", "Swimmer_id": "9", "nationality": "DK",
+     "club": "C", "birth_year": 2003, "completed_time": "DQ",
+     "completed_centiseconds": None, "splits": []},
+]
+
+
+def test_dim_meet_row():
+    row = model.build_dim_meet(MEET)
+    assert row == {"meet_id": "8609", "meet_name": "DM Langbane 2021",
+                   "venue": "Aarhus", "course": "LCM", "season": 2021,
+                   "meet_date": "08-07-2021", "category": ["DM-L", "DMJ-L"]}
+
+
+def test_dim_race_carries_authoritative_class_and_partitions():
+    rows = model.build_dim_race(RACES, {1: "para"}, season=2021, course="LCM")
+    assert rows[0]["class"] == "para"
+    assert rows[0]["season"] == 2021 and rows[0]["course"] == "LCM"
+    assert rows[0]["race_id"] == 1 and rows[0]["meet_id"] == "8609"
+
+
+def test_result_id_uses_ordinal_not_rank_so_dqs_dont_collide():
+    table = {(2021, "LCM", "F", 1, 100, "FREE"): 60.0}
+    races_by_id = {1: RACES[0]}
+    rows = model.build_fact_result(RESULTS, races_by_id, {1: "open"}, table,
+                                   meet_id="8609", season=2021, course="LCM")
+    ids = [r["result_id"] for r in rows]
+    assert ids == ["1-0", "1-1", "1-2"]   # two DQs do NOT collide
+    # First row scored (base 60.0 vs 60.0 swim -> 1000); DQs unscored.
+    assert rows[0]["points"] == 1000 and rows[0]["points_fixed"] is None
+    assert rows[1]["points"] is None and rows[2]["points"] is None
+    assert rows[0]["rank"] == 1 and rows[0]["swimmer_id"] == "7"
+
+
+def test_fact_split_keys_to_result_id():
+    rows = model.build_fact_split(RESULTS, meet_id="8609", season=2021, course="LCM")
+    assert len(rows) == 1                 # only the first result has splits
+    assert rows[0]["result_id"] == "1-0"
+    assert rows[0]["distance"] == 50 and rows[0]["split_centiseconds"] == 2900
+
+
+def test_obt_inlines_meet_and_race_attributes():
+    table = {(2021, "LCM", "F", 1, 100, "FREE"): 60.0}
+    races_by_id = {1: RACES[0]}
+    fact = model.build_fact_result(RESULTS, races_by_id, {1: "open"}, table,
+                                   meet_id="8609", season=2021, course="LCM")
+    obt = model.build_obt(fact, MEET, races_by_id, {1: "open"})
+    assert obt[0]["meet_name"] == "DM Langbane 2021"
+    assert obt[0]["race_name"] == "100 Fri - Damer"
+    assert obt[0]["stroke"] == "Fri" and obt[0]["class"] == "open"
+    assert obt[0]["result_id"] == "1-0" and obt[0]["points"] == 1000

--- a/st-scrape/tests/test_curate_overrides.py
+++ b/st-scrape/tests/test_curate_overrides.py
@@ -1,0 +1,35 @@
+"""Class-overrides table: set/list/get-for-meet."""
+import boto3
+import pytest
+
+from curate.overrides import ClassOverrides
+
+REGION = "eu-west-1"
+TABLE = "swimtrends-class-overrides-test"
+
+
+@pytest.fixture
+def overrides_table(mocked_aws):
+    ddb = boto3.resource("dynamodb", region_name=REGION)
+    ddb.create_table(
+        TableName=TABLE,
+        KeySchema=[{"AttributeName": "meet_id", "KeyType": "HASH"},
+                   {"AttributeName": "race_id", "KeyType": "RANGE"}],
+        AttributeDefinitions=[{"AttributeName": "meet_id", "AttributeType": "S"},
+                              {"AttributeName": "race_id", "AttributeType": "N"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    yield ddb.Table(TABLE)
+
+
+def test_set_then_get_for_meet_returns_race_id_to_class(overrides_table):
+    ov = ClassOverrides(TABLE, region=REGION)
+    ov.set_override("8609", 213, "para", reason="para-only event")
+    ov.set_override("8609", 99, "open", reason="false positive")
+    ov.set_override("9999", 1, "para", reason="other meet")
+    assert ov.get_for_meet("8609") == {213: "para", 99: "open"}
+
+
+def test_get_for_meet_empty_when_none(overrides_table):
+    ov = ClassOverrides(TABLE, region=REGION)
+    assert ov.get_for_meet("8609") == {}

--- a/st-scrape/tests/test_curate_parquet.py
+++ b/st-scrape/tests/test_curate_parquet.py
@@ -1,0 +1,32 @@
+"""Parquet writer: round-trips rows, handles nulls, and builds partition paths."""
+import io
+
+import pyarrow.parquet as pq
+
+from curate import parquet
+
+
+def test_partition_path_per_meet():
+    assert parquet.object_key("fact_result", season=2021, course="LCM", meet_id="8609") == \
+        "curated/fact_result/season=2021/course=LCM/meet=8609.parquet"
+
+
+def test_write_round_trips_with_nulls():
+    rows = [
+        {"result_id": "1-0", "points": 1000, "points_fixed": None,
+         "season": 2021, "course": "LCM"},
+        {"result_id": "1-1", "points": None, "points_fixed": None,
+         "season": 2021, "course": "LCM"},
+    ]
+    data = parquet.write_parquet_bytes("fact_result", rows)
+    table = pq.read_table(io.BytesIO(data))
+    out = table.to_pylist()
+    assert out[0]["result_id"] == "1-0" and out[0]["points"] == 1000
+    assert out[1]["points"] is None
+
+
+def test_empty_rows_still_writes_valid_schema():
+    data = parquet.write_parquet_bytes("fact_split", [])
+    table = pq.read_table(io.BytesIO(data))
+    assert table.num_rows == 0
+    assert "result_id" in table.schema.names

--- a/st-scrape/tests/test_curate_points.py
+++ b/st-scrape/tests/test_curate_points.py
@@ -1,0 +1,56 @@
+"""WA points: formula, stroke mapping, scorability, season vs fixed reference."""
+from curate import points
+
+
+def _table():
+    # (season, course, gender, relay_count, distance, stroke) -> basetime_sec
+    return {
+        (2022, "LCM", "F", 1, 100, "FREE"): 51.71,
+        (2026, "LCM", "F", 1, 100, "FREE"): 50.00,
+    }
+
+
+def test_formula_truncates():
+    # 1000 * (51.71/51.71)**3 == 1000 exactly.
+    assert points.calculate_points(51.71, 51.71) == 1000
+    # Slower swim scores < 1000.
+    assert points.calculate_points(51.71, 60.00) == 640
+
+
+def test_stroke_mapping_im_and_holdmedley_to_medley():
+    assert points.STROKE_MAP["IM"] == "MEDLEY"
+    assert points.STROKE_MAP["HM"] == "MEDLEY"
+    assert points.STROKE_MAP["Fri"] == "FREE"
+
+
+def test_points_for_uses_season_and_fixed_reference():
+    table = _table()
+    race = {"gender": "F", "relay_count": 1, "distance": 100, "stroke": "Fri"}
+    # season 2022 base 51.71 vs a 52.00 swim.
+    assert points.points_for(table, 2022, "LCM", race, 52.00) == 983
+    # fixed reference season 2026 base 50.00 vs the same swim.
+    assert points.points_for(table, 2026, "LCM", race, 52.00) == 888
+
+
+def test_points_for_returns_none_when_no_base_time():
+    table = _table()
+    race = {"gender": "M", "relay_count": 1, "distance": 100, "stroke": "Fri"}
+    assert points.points_for(table, 2022, "LCM", race, 50.0) is None
+
+
+def test_score_result_skips_dq_and_para_and_missing_time():
+    table = _table()
+    race = {"gender": "F", "relay_count": 1, "distance": 100, "stroke": "Fri"}
+    # Normal scorable swim (open).
+    p, pf = points.score_result(table, 2022, "LCM", race, klass="open",
+                                completed_centiseconds=5200, rank=1)
+    assert (p, pf) == (983, 888)
+    # DQ (rank -1) -> not scored.
+    assert points.score_result(table, 2022, "LCM", race, klass="open",
+                               completed_centiseconds=5200, rank=-1) == (None, None)
+    # Missing time -> not scored.
+    assert points.score_result(table, 2022, "LCM", race, klass="open",
+                               completed_centiseconds=None, rank=1) == (None, None)
+    # Para -> never scored even with a valid time.
+    assert points.score_result(table, 2022, "LCM", race, klass="para",
+                               completed_centiseconds=5200, rank=1) == (None, None)

--- a/st-scrape/tests/test_curate_run.py
+++ b/st-scrape/tests/test_curate_run.py
@@ -1,0 +1,51 @@
+"""run_curate_task: read raw -> transform -> write curated parquet -> notify.
+All I/O injected; verifies object keys, overwrite-by-meet, and notification."""
+import io
+
+import pyarrow.parquet as pq
+
+from curate import run
+
+MEET = ('{"meet_id": 8609, "meet": "DM L 2021", "venue": "Aarhus", '
+        '"course": "LCM", "season": 2021, "date": "08-07-2021", "category": ["DM-L"]}')
+RACES = (
+    '{"meet_id": 8609, "race_id": 1, "number": 1, "name": "100 Fri - Damer", '
+    '"distance": 100, "stroke": "Fri", "gender": "F", "relay_count": 1, '
+    '"type": "Final", "class": "open"}\n'
+)
+RESULTS = (
+    '{"race_id": 1, "Rank": 1, "Name": "A", "Swimmer_id": "7", '
+    '"completed_time": "1:00.00", "completed_centiseconds": 6000, "splits": []}\n'
+)
+BASE_TIMES = ('{"season": 2021, "course": "LCM", "gender": "F", "relay_count": 1, '
+              '"distance": 100, "stroke": "FREE", "basetime_in_sec": 60.0}\n')
+
+
+def test_run_writes_all_five_tables_and_notifies():
+    raw = {
+        "raw/meet=8609/meet_info.jsonl": MEET,
+        "raw/meet=8609/races.jsonl": RACES,
+        "raw/meet=8609/results.jsonl": RESULTS,
+        "reference/point_base_times.jsonl": BASE_TIMES,
+    }
+    written, notes = {}, []
+
+    run.run_curate_task(
+        meet_id="8609",
+        read_text=lambda key: raw[key],
+        get_overrides=lambda mid: {},
+        write_bytes=lambda key, data: written.__setitem__(key, data),
+        notify=lambda subject, msg: notes.append(subject),
+    )
+
+    assert set(written) == {
+        "curated/dim_meet/season=2021/course=LCM/meet=8609.parquet",
+        "curated/dim_race/season=2021/course=LCM/meet=8609.parquet",
+        "curated/fact_result/season=2021/course=LCM/meet=8609.parquet",
+        "curated/fact_split/season=2021/course=LCM/meet=8609.parquet",
+        "curated/obt_result/season=2021/course=LCM/meet=8609.parquet",
+    }
+    fr = pq.read_table(io.BytesIO(
+        written["curated/fact_result/season=2021/course=LCM/meet=8609.parquet"]))
+    assert fr.to_pylist()[0]["points"] == 1000
+    assert any("curat" in s.lower() for s in notes)

--- a/st-scrape/tests/test_curate_transform.py
+++ b/st-scrape/tests/test_curate_transform.py
@@ -1,0 +1,32 @@
+"""transform_meet ties model builders together from parsed raw dicts."""
+from curate import transform
+
+MEET = {"meet_id": 8609, "meet": "DM L 2021", "venue": "Aarhus", "course": "LCM",
+        "season": 2021, "date": "08-07-2021", "category": ["DM-L"]}
+RACES = [
+    {"meet_id": 8609, "race_id": 1, "number": 1, "name": "100 Fri - Damer",
+     "distance": 100, "stroke": "Fri", "gender": "F", "relay_count": 1,
+     "type": "Final", "class": "open"},
+    {"meet_id": 8609, "race_id": 2, "number": 2, "name": "100 Fri - Damer",
+     "distance": 100, "stroke": "Fri", "gender": "F", "relay_count": 1,
+     "type": "Timed final", "class": "open"},   # para by heuristic (dup of race 1)
+]
+RESULTS = [
+    {"race_id": 1, "Rank": 1, "Name": "A", "Swimmer_id": "7", "completed_time": "1:00.00",
+     "completed_centiseconds": 6000, "splits": []},
+    {"race_id": 2, "Rank": 1, "Name": "P", "Swimmer_id": "8", "completed_time": "1:10.00",
+     "completed_centiseconds": 7000, "splits": []},
+]
+
+
+def test_transform_produces_all_tables_and_para_is_unscored():
+    base_times = {(2021, "LCM", "F", 1, 100, "FREE"): 60.0}
+    tables = transform.transform_meet(MEET, RACES, RESULTS, base_times, overrides={})
+    assert set(tables) == {"dim_meet", "dim_race", "fact_result", "fact_split", "obt_result"}
+    assert len(tables["dim_meet"]) == 1
+    # Race 2 is para (Timed final duplicating race 1's name) -> dim_race says so.
+    race_class = {r["race_id"]: r["class"] for r in tables["dim_race"]}
+    assert race_class == {1: "open", 2: "para"}
+    # Open result scored, para result unscored.
+    pts = {r["race_id"]: r["points"] for r in tables["fact_result"]}
+    assert pts[1] == 1000 and pts[2] is None

--- a/st-scrape/tests/test_dispatcher.py
+++ b/st-scrape/tests/test_dispatcher.py
@@ -137,3 +137,118 @@ def test_run_task_failure_marks_failed_and_notifies(dynamodb_table):
     assert dispatched == []
     assert reg.get("1")["status"] == "failed"
     assert any("failed" in s.lower() for s, _ in rec.notes)
+
+
+# --------------------------------------------------------------------------
+# run_reaper: resolve meets orphaned in 'scraping' when their container died
+# --------------------------------------------------------------------------
+
+def _stale_scraping(reg, meet_id):
+    """A meet claimed long ago and never finished -> orphaned in 'scraping'."""
+    reg.put_meet(meet_id, ["DO"], "2024-07-11")
+    reg.claim(meet_id, when="2020-01-01T00:00:00Z")
+
+
+def test_reaper_reconciles_orphan_with_complete_raw_data(dynamodb_table):
+    reg = MeetRegistry(TABLE_NAME, region="eu-west-1")
+    _stale_scraping(reg, "8609")
+    rec = Recorder()
+    # All three raw files are present in S3 -> a lost terminal write.
+    reconcile = lambda mid: {"meet_name": "Forced Open", "result_count": 1603,
+                             "race_count": 64}
+    resolved = dispatcher.run_reaper(
+        reg, now=at(2026, 6, 17, 12), reconcile=reconcile, notify=rec.notify)
+    assert resolved == [("8609", "reconciled")]
+    item = reg.get("8609")
+    assert item["status"] == "scraped"
+    assert int(item["result_count"]) == 1603
+    assert int(item["race_count"]) == 64
+
+
+def test_reaper_reclaims_orphan_without_raw_data(dynamodb_table):
+    reg = MeetRegistry(TABLE_NAME, region="eu-west-1")
+    _stale_scraping(reg, "8609")
+    rec = Recorder()
+    # Raw files absent/incomplete -> nothing to reconcile, reset for retry.
+    resolved = dispatcher.run_reaper(
+        reg, now=at(2026, 6, 17, 12), reconcile=lambda mid: None,
+        notify=rec.notify)
+    assert resolved == [("8609", "reclaimed")]
+    assert reg.get("8609")["status"] == "failed"
+    assert any("8609" in m for _, m in rec.notes)
+
+
+def test_reaper_leaves_fresh_scraping_meet_alone(dynamodb_table):
+    reg = MeetRegistry(TABLE_NAME, region="eu-west-1")
+    reg.put_meet("1", ["DO"], "2024-07-11")
+    reg.claim("1", when="2026-06-17T11:30:00Z")  # claimed 30 min ago
+    rec = Recorder()
+
+    def fail_if_called(mid):
+        raise AssertionError("must not reconcile a fresh scrape")
+
+    resolved = dispatcher.run_reaper(
+        reg, now=at(2026, 6, 17, 12), reconcile=fail_if_called,
+        notify=rec.notify)
+    assert resolved == []
+    assert reg.get("1")["status"] == "scraping"
+
+
+def test_reaper_treats_missing_claimed_at_as_stale(dynamodb_table):
+    # Legacy rows claimed before claimed_at existed must still be reapable.
+    reg = MeetRegistry(TABLE_NAME, region="eu-west-1")
+    reg.put_meet("1", ["DO"], "2024-07-11")
+    dynamodb_table.update_item(
+        Key={"meet_id": "1"},
+        UpdateExpression="SET #s = :scraping",
+        ExpressionAttributeNames={"#s": "status"},
+        ExpressionAttributeValues={":scraping": "scraping"})
+    rec = Recorder()
+    resolved = dispatcher.run_reaper(
+        reg, now=at(2026, 6, 17, 12), reconcile=lambda mid: None,
+        notify=rec.notify)
+    assert resolved == [("1", "reclaimed")]
+
+
+def test_reconcile_raw_counts_complete_meet():
+    files = {
+        "raw/meet=8609/meet_info.jsonl": '{"meet": "Forced Open"}\n',
+        "raw/meet=8609/races.jsonl": "a\nb\nc\n",
+        "raw/meet=8609/results.jsonl": "1\n2\n\n3\n",  # blank line ignored
+    }
+    counts = dispatcher.reconcile_raw(lambda key: files.get(key), "8609")
+    assert counts == {"meet_name": "Forced Open", "result_count": 3,
+                      "race_count": 3}
+
+
+def test_reconcile_raw_returns_none_when_a_file_is_missing():
+    files = {
+        "raw/meet=8609/meet_info.jsonl": '{"meet": "X"}\n',
+        "raw/meet=8609/races.jsonl": "a\n",
+        # results.jsonl absent -> incomplete scrape, cannot reconcile
+    }
+    assert dispatcher.reconcile_raw(lambda key: files.get(key), "8609") is None
+
+
+def test_reconcile_raw_returns_none_when_meet_info_empty():
+    files = {
+        "raw/meet=8609/meet_info.jsonl": "",
+        "raw/meet=8609/races.jsonl": "a\n",
+        "raw/meet=8609/results.jsonl": "1\n",
+    }
+    assert dispatcher.reconcile_raw(lambda key: files.get(key), "8609") is None
+
+
+def test_reaper_ignores_non_scraping_meets(dynamodb_table):
+    reg = MeetRegistry(TABLE_NAME, region="eu-west-1")
+    reg.put_meet("1", ["DO"], "2024-07-11")  # scheduled, untouched
+    rec = Recorder()
+
+    def fail_if_called(mid):
+        raise AssertionError("must not touch a scheduled meet")
+
+    resolved = dispatcher.run_reaper(
+        reg, now=at(2026, 6, 17, 12), reconcile=fail_if_called,
+        notify=rec.notify)
+    assert resolved == []
+    assert reg.get("1")["status"] == "scheduled"

--- a/st-scrape/tests/test_registry.py
+++ b/st-scrape/tests/test_registry.py
@@ -86,6 +86,47 @@ def test_reset_returns_to_scheduled(dynamodb_table):
     assert "last_error" not in item
 
 
+def test_claim_records_claimed_at(dynamodb_table):
+    reg = make_registry()
+    reg.put_meet("10970", ["DO"], "2024-07-11")
+    reg.claim("10970", when="2026-06-17T09:00:00Z")
+    item = dynamodb_table.get_item(Key={"meet_id": "10970"})["Item"]
+    assert item["claimed_at"] == "2026-06-17T09:00:00Z"
+
+
+def test_scraping_meets_returns_only_in_flight(dynamodb_table):
+    reg = make_registry()
+    reg.put_meet("1", ["DO"], "2024-01-01")  # scheduled
+    reg.put_meet("2", ["DO"], "2024-01-02")
+    reg.claim("2")  # scraping
+    reg.put_meet("3", ["DO"], "2024-01-03")
+    reg.claim("3")
+    reg.mark_scraped("3", "Meet 3", 10, 3)  # scraped
+    reg.put_meet("4", ["DO"], "2024-01-04")
+    reg.claim("4")
+    reg.mark_failed("4", "boom")  # failed
+    ids = {m["meet_id"] for m in reg.scraping_meets()}
+    assert ids == {"2"}
+
+
+def test_mark_scraped_clears_claimed_at(dynamodb_table):
+    reg = make_registry()
+    reg.put_meet("10970", ["DO"], "2024-07-11")
+    reg.claim("10970")
+    reg.mark_scraped("10970", "Meet", 10, 3)
+    item = dynamodb_table.get_item(Key={"meet_id": "10970"})["Item"]
+    assert "claimed_at" not in item
+
+
+def test_mark_failed_clears_claimed_at(dynamodb_table):
+    reg = make_registry()
+    reg.put_meet("10970", ["DO"], "2024-07-11")
+    reg.claim("10970")
+    reg.mark_failed("10970", "boom")
+    item = dynamodb_table.get_item(Key={"meet_id": "10970"})["Item"]
+    assert "claimed_at" not in item
+
+
 def test_get_returns_none_for_missing(dynamodb_table):
     reg = make_registry()
     assert reg.get("does-not-exist") is None

--- a/swimtrends-app/app.py
+++ b/swimtrends-app/app.py
@@ -3,6 +3,7 @@
 import aws_cdk as cdk
 
 from swimtrends_app.swimtrends_app_stack import SwimtrendsAppStack
+from swimtrends_app.swimtrends_curated_stack import SwimtrendsCuratedStack
 from swimtrends_app.swimtrends_ingestion_stack import SwimtrendsIngestionStack
 
 ENV = cdk.Environment(account="179537025528", region="eu-west-1")
@@ -13,6 +14,12 @@ SwimtrendsAppStack(app, "SwimtrendsAppStack", env=ENV)
 
 SwimtrendsIngestionStack(
     app, "SwimtrendsIngestionStack",
+    alert_email=app.node.try_get_context("alert_email"),
+    env=ENV,
+)
+
+SwimtrendsCuratedStack(
+    app, "SwimtrendsCuratedStack",
     alert_email=app.node.try_get_context("alert_email"),
     env=ENV,
 )

--- a/swimtrends-app/lambda_curate_trigger/curate_trigger.py
+++ b/swimtrends-app/lambda_curate_trigger/curate_trigger.py
@@ -1,0 +1,36 @@
+"""S3 ObjectCreated(raw/.../results.jsonl) -> RunTask the curate Fargate task
+for that meet. Parses meet_id from the key 'raw/meet=<id>/results.jsonl'."""
+import os
+import re
+
+import boto3
+
+KEY_RE = re.compile(r"raw/meet=([^/]+)/results\.jsonl$")
+
+
+def lambda_handler(event, context):
+    ecs = boto3.client("ecs")
+    launched = []
+    for record in event.get("Records", []):
+        key = record["s3"]["object"]["key"]
+        m = KEY_RE.search(key)
+        if not m:
+            continue
+        meet_id = m.group(1)
+        ecs.run_task(
+            cluster=os.environ["ECS_CLUSTER"],
+            taskDefinition=os.environ["TASK_DEFINITION"],
+            launchType="FARGATE",
+            count=1,
+            networkConfiguration={"awsvpcConfiguration": {
+                "subnets": os.environ["SUBNET_IDS"].split(","),
+                "securityGroups": [os.environ["SECURITY_GROUP_ID"]],
+                "assignPublicIp": "ENABLED",
+            }},
+            overrides={"containerOverrides": [{
+                "name": os.environ["CONTAINER_NAME"],
+                "environment": [{"name": "MEET_ID", "value": meet_id}],
+            }]},
+        )
+        launched.append(meet_id)
+    return {"launched": launched}

--- a/swimtrends-app/requirements.txt
+++ b/swimtrends-app/requirements.txt
@@ -1,2 +1,3 @@
 aws-cdk-lib==2.257.0
 constructs>=10.0.0,<11.0.0
+pyarrow>=15.0

--- a/swimtrends-app/swimtrends_app/swimtrends_curated_stack.py
+++ b/swimtrends-app/swimtrends_app/swimtrends_curated_stack.py
@@ -1,0 +1,145 @@
+"""Swimtrends curated zone (Spec 2 of 3).
+
+A class-overrides DynamoDB table, a Fargate task that runs the curated transform,
+an S3-event trigger Lambda (raw results.jsonl -> RunTask), a Glue database with
+one table per curated dataset, and SNS alerts. Reuses the swimtrends-meet-data
+bucket and the ingestion ECS cluster by name."""
+import os
+import sys
+
+from aws_cdk import Duration, Stack
+from aws_cdk import aws_dynamodb as dynamodb
+from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_ecs as ecs
+from aws_cdk import aws_glue as glue
+from aws_cdk import aws_iam as iam
+from aws_cdk import aws_lambda as lambda_
+from aws_cdk import aws_logs as logs
+from aws_cdk import aws_s3 as s3
+from aws_cdk import aws_s3_notifications as s3n
+from aws_cdk import aws_sns as sns
+from aws_cdk import aws_sns_subscriptions as subs
+from constructs import Construct
+
+ST_SCRAPE_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "st-scrape"))
+sys.path.insert(0, ST_SCRAPE_DIR)
+from curate import catalog  # noqa: E402  (import after path insert)
+
+CONTAINER_NAME = "curate"
+BUCKET_NAME = "swimtrends-meet-data"
+CURATED_TABLES = ["dim_meet", "dim_race", "fact_result", "fact_split", "obt_result"]
+
+
+class SwimtrendsCuratedStack(Stack):
+
+    def __init__(self, scope: Construct, construct_id: str,
+                 alert_email: str = None, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        bucket = s3.Bucket.from_bucket_name(self, "DataBucket", BUCKET_NAME)
+
+        overrides = dynamodb.Table(
+            self, "ClassOverrides",
+            table_name="swimtrends-class-overrides",
+            partition_key=dynamodb.Attribute(
+                name="meet_id", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(
+                name="race_id", type=dynamodb.AttributeType.NUMBER),
+            billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
+        )
+
+        topic = sns.Topic(self, "CurateAlertTopic",
+                          display_name="Swimtrends curate alerts")
+        if alert_email:
+            topic.add_subscription(subs.EmailSubscription(alert_email))
+
+        vpc = ec2.Vpc.from_lookup(self, "DefaultVpc", is_default=True)
+        sg = ec2.SecurityGroup(self, "CurateTaskSG", vpc=vpc,
+                               allow_all_outbound=True,
+                               description="Egress-only SG for the curate task")
+        cluster = ecs.Cluster.from_cluster_attributes(
+            self, "Cluster", cluster_name="swimtrends-ingestion",
+            vpc=vpc, security_groups=[])
+
+        task_def = ecs.FargateTaskDefinition(
+            self, "CurateTaskDef", cpu=512, memory_limit_mib=1024)
+        task_def.add_container(
+            CONTAINER_NAME,
+            image=ecs.ContainerImage.from_asset(
+                ST_SCRAPE_DIR, file="Dockerfile.curate"),
+            logging=ecs.LogDriver.aws_logs(
+                stream_prefix="curate",
+                log_retention=logs.RetentionDays.ONE_MONTH),
+            environment={
+                "CURATED_BUCKET": BUCKET_NAME,
+                "OVERRIDES_TABLE": overrides.table_name,
+                "SNS_TOPIC_ARN": topic.topic_arn,
+            },
+        )
+        bucket.grant_read(task_def.task_role, objects_key_pattern="raw/*")
+        bucket.grant_read(task_def.task_role, objects_key_pattern="reference/*")
+        bucket.grant_put(task_def.task_role, objects_key_pattern="curated/*")
+        overrides.grant_read_data(task_def.task_role)
+        topic.grant_publish(task_def.task_role)
+
+        # --- S3-event trigger Lambda: raw results.jsonl lands -> RunTask ---
+        trigger_fn = lambda_.Function(
+            self, "CurateTrigger",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            handler="curate_trigger.lambda_handler",
+            timeout=Duration.minutes(1),
+            memory_size=256,
+            code=lambda_.Code.from_asset(
+                os.path.join(os.path.dirname(__file__), "..", "lambda_curate_trigger")),
+            environment={
+                "ECS_CLUSTER": cluster.cluster_arn,
+                "TASK_DEFINITION": task_def.task_definition_arn,
+                "CONTAINER_NAME": CONTAINER_NAME,
+                "SUBNET_IDS": ",".join(s.subnet_id for s in vpc.public_subnets),
+                "SECURITY_GROUP_ID": sg.security_group_id,
+            },
+        )
+        trigger_fn.add_to_role_policy(iam.PolicyStatement(
+            actions=["ecs:RunTask"], resources=[task_def.task_definition_arn]))
+        trigger_fn.add_to_role_policy(iam.PolicyStatement(
+            actions=["iam:PassRole"],
+            resources=[task_def.task_role.role_arn,
+                       task_def.obtain_execution_role().role_arn]))
+
+        bucket.add_event_notification(
+            s3.EventType.OBJECT_CREATED,
+            s3n.LambdaDestination(trigger_fn),
+            s3.NotificationKeyFilter(prefix="raw/", suffix="results.jsonl"))
+
+        # --- Glue catalog ---
+        db = glue.CfnDatabase(
+            self, "CuratedDatabase",
+            catalog_id=self.account,
+            database_input=glue.CfnDatabase.DatabaseInputProperty(
+                name="swimtrends_curated"))
+        for name in CURATED_TABLES:
+            location = f"s3://{BUCKET_NAME}/curated/{name}/"
+            ti = catalog.table_input(name, location)
+            tbl = glue.CfnTable(
+                self, f"Table{name}",
+                catalog_id=self.account,
+                database_name="swimtrends_curated",
+                table_input=glue.CfnTable.TableInputProperty(
+                    name=ti["Name"],
+                    table_type=ti["TableType"],
+                    parameters=ti["Parameters"],
+                    partition_keys=[
+                        glue.CfnTable.ColumnProperty(name=c["Name"], type=c["Type"])
+                        for c in ti["PartitionKeys"]],
+                    storage_descriptor=glue.CfnTable.StorageDescriptorProperty(
+                        columns=[glue.CfnTable.ColumnProperty(
+                            name=c["Name"], type=c["Type"])
+                            for c in ti["StorageDescriptor"]["Columns"]],
+                        location=location,
+                        input_format=ti["StorageDescriptor"]["InputFormat"],
+                        output_format=ti["StorageDescriptor"]["OutputFormat"],
+                        serde_info=glue.CfnTable.SerdeInfoProperty(
+                            serialization_library=ti["StorageDescriptor"]
+                            ["SerdeInfo"]["SerializationLibrary"]))))
+            tbl.add_dependency(db)

--- a/swimtrends-app/swimtrends_app/swimtrends_ingestion_stack.py
+++ b/swimtrends-app/swimtrends_app/swimtrends_ingestion_stack.py
@@ -105,6 +105,7 @@ class SwimtrendsIngestionStack(Stack):
             ),
             environment={
                 "REGISTRY_TABLE": registry.table_name,
+                "RAW_BUCKET": RAW_BUCKET_NAME,
                 "SNS_TOPIC_ARN": topic.topic_arn,
                 "ECS_CLUSTER": cluster.cluster_arn,
                 "TASK_DEFINITION": task_def.task_definition_arn,
@@ -114,11 +115,14 @@ class SwimtrendsIngestionStack(Stack):
                 "SECURITY_GROUP_ID": scrape_sg.security_group_id,
                 "REFERENCE_TZ": "Europe/Copenhagen",
                 "MAX_ATTEMPTS": "3",
+                "REAP_TTL_HOURS": "6",
             },
         )
 
-        # Dispatcher permissions: read/update registry, launch tasks, alert.
+        # Dispatcher permissions: read/update registry, launch tasks, alert,
+        # and read raw objects to reconcile meets orphaned in 'scraping'.
         registry.grant_read_write_data(dispatcher_fn)
+        raw_bucket.grant_read(dispatcher_fn, objects_key_pattern="raw/*")
         topic.grant_publish(dispatcher_fn)
         dispatcher_fn.add_to_role_policy(iam.PolicyStatement(
             actions=["ecs:RunTask"],

--- a/swimtrends-app/tests/unit/test_curated_stack.py
+++ b/swimtrends-app/tests/unit/test_curated_stack.py
@@ -1,0 +1,57 @@
+"""Synth assertions for the curated stack: overrides table, curate task,
+trigger Lambda, Glue database + tables. VPC context is stubbed so from_lookup
+does not require AWS credentials."""
+import aws_cdk as cdk
+from aws_cdk import assertions
+
+from swimtrends_app.swimtrends_curated_stack import SwimtrendsCuratedStack
+
+ENV = cdk.Environment(account="179537025528", region="eu-west-1")
+
+_VPC_CONTEXT = {
+    "vpc-provider:account=179537025528:filter.isDefault=true:region=eu-west-1:returnAsymmetricSubnets=true": {
+        "vpcId": "vpc-12345",
+        "vpcCidrBlock": "10.0.0.0/16",
+        "availabilityZones": [],
+        "subnetGroups": [{
+            "name": "Public",
+            "type": "Public",
+            "subnets": [
+                {"subnetId": "subnet-1", "availabilityZone": "eu-west-1a",
+                 "routeTableId": "rtb-1", "cidr": "10.0.0.0/24"},
+                {"subnetId": "subnet-2", "availabilityZone": "eu-west-1b",
+                 "routeTableId": "rtb-2", "cidr": "10.0.1.0/24"},
+            ],
+        }],
+    }
+}
+
+
+def _template():
+    app = cdk.App(context=_VPC_CONTEXT)
+    stack = SwimtrendsCuratedStack(app, "TestCurated", alert_email=None, env=ENV)
+    return assertions.Template.from_stack(stack)
+
+
+def test_overrides_table_has_composite_key():
+    t = _template()
+    t.has_resource_properties("AWS::DynamoDB::Table", {
+        "TableName": "swimtrends-class-overrides",
+        "KeySchema": [
+            {"AttributeName": "meet_id", "KeyType": "HASH"},
+            {"AttributeName": "race_id", "KeyType": "RANGE"},
+        ],
+    })
+
+
+def test_glue_database_and_five_tables():
+    t = _template()
+    t.resource_count_is("AWS::Glue::Database", 1)
+    t.resource_count_is("AWS::Glue::Table", 5)
+
+
+def test_trigger_lambda_exists():
+    t = _template()
+    t.has_resource_properties("AWS::Lambda::Function", {
+        "Handler": "curate_trigger.lambda_handler",
+    })

--- a/swimtrends-app/tests/unit/test_ingestion_stack.py
+++ b/swimtrends-app/tests/unit/test_ingestion_stack.py
@@ -83,3 +83,26 @@ def test_dispatcher_can_run_ecs_tasks():
             ]),
         },
     })
+
+
+def test_dispatcher_has_raw_bucket_for_reaper():
+    # The reaper reconciles orphaned meets from the raw zone, so the dispatcher
+    # needs the bucket name and read access to raw/*.
+    t = _synth()
+    t.has_resource_properties("AWS::Lambda::Function", {
+        "Handler": "ingestion.dispatcher.lambda_handler",
+        "Environment": {"Variables": Match.object_like({
+            "RAW_BUCKET": "swimtrends-meet-data",
+            "REAP_TTL_HOURS": "6",
+        })},
+    })
+    t.has_resource_properties("AWS::IAM::Policy", {
+        "PolicyDocument": {
+            "Statement": Match.array_with([
+                Match.object_like({
+                    "Action": Match.array_with(
+                        [Match.string_like_regexp("^s3:GetObject")]),
+                }),
+            ]),
+        },
+    })


### PR DESCRIPTION
Lands Spec 2 (the curated data lake) and the orphaned-scraping reaper on top of the squashed ingestion platform now in master. Linear history, 19 commits.

## Curated zone (Spec 2 of 3) — built + deployed 2026-06-08
- Fargate-Python transform of raw meets → partitioned Parquet (`season`/`course`) under `curated/<table>/...`.
- World Aquatics points (`points` season-relative + `points_fixed` vs 2026) and authoritative race class (override-else-heuristic; para excluded from points).
- Conformed `dim_meet`/`dim_race`/`fact_result`/`fact_split` + one-big-table `obt_result`, all in Glue catalog `swimtrends_curated`.
- `SwimtrendsCuratedStack`: class-overrides DynamoDB table, curate Fargate task, S3 ObjectCreated trigger Lambda, Glue DB + 5 tables, alert topic.
- CLI: `swimtrends curate [meet|--all]` and `class set <meet> <race_id> <open|para>`.

## Orphaned-scraping reaper — built + deployed 2026-06-17
- Fixes meets stranded in `status=scraping` when a scrape container dies after its S3 uploads but before `mark_scraped` (the meet 8609 case).
- `claim()` now stamps `claimed_at`; the hourly dispatcher runs `run_reaper()` (full cycles only) to find stale claims (> `REAP_TTL_HOURS`, default 6h; missing timestamp = stale for legacy rows).
- Each orphan is **reconciled from the raw zone** when all three files are present (a lost terminal write → `mark_scraped`, no re-scrape) or **reset to `failed`** for retry. Both paths notify via SNS.
- Dispatcher Lambda gained `RAW_BUCKET` + `REAP_TTL_HOURS` env and read access to `raw/*`.

## Tests
84 st-scrape (pytest + moto) + 11 CDK assertion tests, all green on the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)